### PR TITLE
fix: stop masking CI test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
@@ -30,7 +29,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest tests/ -v --cov=src --cov-report=xml || echo "Tests need dependency update"
+        pytest tests/ -v --cov=src --cov-report=xml
 
     - name: Upload coverage
       uses: codecov/codecov-action@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.9"
 dependencies = [
-    "pygls>=1.2.0",
+    "pygls>=1.2.0,<2.0.0",
     "lsprotocol>=2023.0.0",
 ]
 


### PR DESCRIPTION
## Summary
- remove the job-level `continue-on-error` setting from CI
- let the pytest step fail normally instead of replacing failures with an echo
- constrain `pygls` to the compatible pre-2.x API line so strict CI resolves a working dependency set

## Verification
- Initial strict local run failed during collection with `ImportError: cannot import name 'LanguageServer' from 'pygls.server'` after resolving `pygls 2.1.1`
- After adding `pygls>=1.2.0,<2.0.0`:
  - `python3.12` temporary virtualenv outside the repo
  - `pip install -e ".[dev]"`
  - `pytest tests/ -v --cov=src --cov-report=xml` -> 178 passed

Closes #26
