### PR TITLE
ci: fail on test errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    continue-on-error: true
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12']
@@ -30,7 +29,7 @@ jobs:
 
     - name: Run tests
       run: |
-        pytest tests/ -v --cov=src --cov-report=xml || echo "Tests need dependency update"
+        pytest tests/ -v --cov=src --cov-report=xml
 
     - name: Upload coverage
       uses: codecov/codecov-action@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 license = {text = "MIT"}
 requires-python = ">=3.9"
 dependencies = [
-    "pygls>=1.2.0",
+    "pygls>=1.2,<2.0",
     "lsprotocol>=2023.0.0",
 ]
 


### PR DESCRIPTION
## Summary
- Let the CI test job fail when pytest fails instead of masking failures with `continue-on-error` and `|| echo`.
- Bound `pygls` to the currently supported 1.x API so the unmasked test job installs dependencies that match the code's `LanguageServer` import.

Fixes #26

## Test Plan
- [x] Reproduced the current workflow masking with a forced-failing pytest invocation; the `pytest ... || echo "Tests need dependency update"` pattern exited 0.
- [x] `.venv/bin/python -m pip install -e "/Users/clawuser/workspace/oss-repos/newtontech/gamess-lsp[dev]" --upgrade`
- [x] `.venv/bin/python -m pytest /Users/clawuser/workspace/oss-repos/newtontech/gamess-lsp/tests -v --cov=src --cov-report=xml` (`178 passed`)
