### PR TITLE
fix: remove unused imports from test files

### DIFF
--- a/tests/test_semantic_validation.py
+++ b/tests/test_semantic_validation.py
@@ -1,9 +1,7 @@
 """Tests for semantic validation."""
 
-import pytest
-
 from gamess_lsp.parser import GAMESSParser
-from gamess_lsp.validator import SemanticValidator, validate_semantics
+from gamess_lsp.validator import validate_semantics
 
 
 class TestSCFTYPMultValidation:

--- a/tests/test_validation_accuracy.py
+++ b/tests/test_validation_accuracy.py
@@ -1,7 +1,5 @@
 """Validation accuracy tests — behavior-oriented test suite for GAMESS LSP diagnostics."""
 
-import pytest
-
 from gamess_lsp.parser import GAMESSParser, parse_gamess_input
 from gamess_lsp.validator import validate_semantics
 


### PR DESCRIPTION
## Summary

Removes unused imports left behind by the test quality improvements merged in the prior cleanup PRs.

### Changes
- Remove unused `pytest` import from `test_semantic_validation.py`
- Remove unused `SemanticValidator` import from `test_semantic_validation.py`
- Remove unused `pytest` import from `test_validation_accuracy.py`

All three were flagged as F401 (imported but unused) by flake8/ruff.

### Verification
- All 186 tests pass
- flake8 clean on both files

Refs #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)