### PR TITLE
fix: remove dead code and unused imports in source modules

### DIFF
--- a/src/gamess_lsp/parser.py
+++ b/src/gamess_lsp/parser.py
@@ -133,7 +133,6 @@ class GAMESSParser:
         lines = content.split("\n")
 
         current_group: Optional[GAMESSGroup] = None
-        in_data_group = False
         data_line_count = 0  # Track lines within $DATA for title/symmetry skip
         geometry_lines: List[Tuple[int, str]] = []
 
@@ -152,7 +151,6 @@ class GAMESSParser:
                         current_group.line_end = line_num
                         result.add_group(current_group)
                         if current_group.name == "DATA":
-                            in_data_group = False
                             data_line_count = 0
                         current_group = None
                     continue
@@ -172,7 +170,6 @@ class GAMESSParser:
 
                     # Track if we're entering $DATA group
                     if group_name == "DATA":
-                        in_data_group = True
                         data_line_count = 0
 
                     # Parse keywords in this line (after the group name)

--- a/src/gamess_lsp/validator.py
+++ b/src/gamess_lsp/validator.py
@@ -4,9 +4,8 @@ This module provides physics/chemistry-aware validation that goes beyond
 syntax checking to detect semantically incorrect but syntactically valid inputs.
 """
 
-import re
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from .constants import ELEMENT_ATOMIC_NUMBERS
 from .parser import GAMESSGroup, GAMESSInputFile
@@ -174,7 +173,7 @@ class SemanticValidator:
                 SemanticDiagnostic(
                     line=line,
                     message=f"SCFTYP={scftyp} 不支持 MULT={mult}。{constraint['description']}"
-                    + (f"\n建议：对于开壳层体系，使用 UHF 或 ROHF。" if scftyp == "RHF" else ""),
+                    + ("\n建议：对于开壳层体系，使用 UHF 或 ROHF。" if scftyp == "RHF" else ""),
                     severity="error",
                     code="SCFTYP_MULT_INCOMPAT",
                 )


### PR DESCRIPTION
## Summary

Cleans up lint violations left behind by the code quality refactor merged for #21 and #23.

### Changes

**`src/gamess_lsp/parser.py`**
- Remove unused `in_data_group` variable (F841: assigned but never read)

**`src/gamess_lsp/validator.py`**
- Remove unused `import re` (F401)
- Remove unused `Tuple` from typing imports (F401)
- Fix f-string without placeholders on the ROHF suggestion line (F541)

### Verification
- All 186 tests pass
- flake8 clean on both files
- No behavior change

Refs #21, Refs #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)