### PR TITLE
feat: add mutual exclusivity and cross-group validation rules

### DIFF
--- a/src/gamess_lsp/validator.py
+++ b/src/gamess_lsp/validator.py
@@ -2,6 +2,11 @@
 
 This module provides physics/chemistry-aware validation that goes beyond
 syntax checking to detect semantically incorrect but syntactically valid inputs.
+
+Coverage note: This validator implements a safe, tested subset of GAMESS
+parameter constraints. It does NOT claim exhaustive scientific validation
+of all possible GAMESS input combinations. See the validation accuracy
+framework (tests/validation/) for measured coverage.
 """
 
 import re
@@ -50,7 +55,7 @@ class SemanticValidator:
         },
     }
 
-    # Method incompatibilities
+    # Method incompatibilities -- mutually exclusive post-HF / DFT methods
     METHOD_INCOMPATIBILITIES = [
         {
             "condition": lambda kws: kws.get("DFTTYP") and kws.get("MPLEVL") == "2",
@@ -69,6 +74,30 @@ class SemanticValidator:
             "message": "MP2 与 Coupled Cluster 不能同时使用。请选择 MPLEVL=2 或 CCTYP 其中之一。",
             "severity": "error",
             "code": "INCOMPAT_MP2_CC",
+        },
+        {
+            "condition": lambda kws: kws.get("MPLEVL") == "2" and kws.get("CITYP"),
+            "message": "MP2 与 CI 不能同时使用。MPLEVL=2 启用 MP2，CITYP 启用 CI 方法，二者互斥。",
+            "severity": "error",
+            "code": "INCOMPAT_MP2_CI",
+        },
+        {
+            "condition": lambda kws: kws.get("CCTYP") and kws.get("CITYP"),
+            "message": "Coupled Cluster 与 CI 不能同时使用。请选择 CCTYP 或 CITYP 其中之一。",
+            "severity": "error",
+            "code": "INCOMPAT_CC_CI",
+        },
+        {
+            "condition": lambda kws: kws.get("DFTTYP") and kws.get("CITYP"),
+            "message": "DFT 与 CI 不能同时使用。请选择 DFTTYP 或 CITYP 其中之一。",
+            "severity": "error",
+            "code": "INCOMPAT_DFT_CI",
+        },
+        {
+            "condition": lambda kws: kws.get("SCFTYP") == "ROHF" and kws.get("MPLEVL") == "2",
+            "message": "ROHF 与 MP2 不兼容。GAMESS 中 MP2 不支持 ROHF 参考。请使用 RHF 或 UHF。",
+            "severity": "error",
+            "code": "INCOMPAT_ROHF_MP2",
         },
         {
             "condition": lambda kws: kws.get("DFTTYP") and kws.get("SCFTYP") == "ROHF",
@@ -113,6 +142,36 @@ class SemanticValidator:
         },
     }
 
+    # Cross-group conflicts: groups that should not coexist
+    CROSS_GROUP_CONFLICTS = [
+        {
+            "group_a": "SCF",
+            "group_b": "MCSCF",
+            "condition": lambda kws: kws.get("SCFTYP") == "MCSCF",
+            "message": "$SCF 组与 $MCSCF 组不应同时出现。MCSCF 计算应使用 $MCSCF 组而非 $SCF 组。",
+            "severity": "warning",
+            "code": "CONFLICT_SCF_MCSCF",
+        },
+    ]
+
+    # RUNTYP values that are incompatible with certain method choices
+    RUNTYP_METHOD_CONSTRAINTS = [
+        {
+            "runtyp": "SURFACE",
+            "forbidden_kws": {"CCTYP": True},
+            "message": "RUNTYP=SURFACE 不支持 Coupled Cluster 计算。",
+            "severity": "error",
+            "code": "INCOMPAT_SURFACE_CC",
+        },
+        {
+            "runtyp": "DRC",
+            "forbidden_kws": {"MPLEVL": "2"},
+            "message": "RUNTYP=DRC (经典轨迹) 不支持 MP2 方法。DRC 需要 SCF 或 DFT 级别的势能面。",
+            "severity": "error",
+            "code": "INCOMPAT_DRC_MP2",
+        },
+    ]
+
     def validate(self, parsed_input: GAMESSInputFile) -> List[SemanticDiagnostic]:
         """Validate a parsed GAMESS input file.
 
@@ -142,6 +201,12 @@ class SemanticValidator:
 
         # 4. Validate required groups
         diagnostics.extend(self._validate_required_groups(parsed_input, contrl_kws))
+
+        # 5. Validate cross-group conflicts
+        diagnostics.extend(self._validate_cross_group_conflicts(parsed_input, contrl, contrl_kws))
+
+        # 6. Validate RUNTYP vs method constraints
+        diagnostics.extend(self._validate_runtyp_method(contrl, contrl_kws))
 
         return diagnostics
 
@@ -252,11 +317,11 @@ class SemanticValidator:
 
         # Check if electron count is consistent with multiplicity
         # Physics:
-        # - MULT=1 (singlet): 0 unpaired → even electrons
-        # - MULT=2 (doublet): 1 unpaired → odd electrons
-        # - MULT=3 (triplet): 2 unpaired → even electrons
-        # - MULT=4 (quartet): 3 unpaired → odd electrons
-        # Pattern: odd MULT → even electrons, even MULT → odd electrons
+        # - MULT=1 (singlet): 0 unpaired -> even electrons
+        # - MULT=2 (doublet): 1 unpaired -> odd electrons
+        # - MULT=3 (triplet): 2 unpaired -> even electrons
+        # - MULT=4 (quartet): 3 unpaired -> odd electrons
+        # Pattern: odd MULT -> even electrons, even MULT -> odd electrons
         # So: mult_mod_2 != electrons_mod_2 for valid combinations
         electrons_mod_2 = total_electrons % 2
         mult_mod_2 = mult % 2
@@ -336,6 +401,91 @@ class SemanticValidator:
                         )
                     )
                     break  # Only report once
+
+        return diagnostics
+
+    def _validate_cross_group_conflicts(
+        self, parsed_input: GAMESSInputFile, contrl: GAMESSGroup, contrl_kws: Dict[str, str]
+    ) -> List[SemanticDiagnostic]:
+        """Validate that conflicting groups are not present together."""
+        diagnostics = []
+
+        for rule in self.CROSS_GROUP_CONFLICTS:
+            group_a = parsed_input.get_group(rule["group_a"])
+            group_b = parsed_input.get_group(rule["group_b"])
+            if group_a and group_b:
+                # Additional condition check if present
+                if "condition" in rule and not rule["condition"](contrl_kws):
+                    continue
+                diagnostics.append(
+                    SemanticDiagnostic(
+                        line=contrl.line_start,
+                        message=rule["message"],
+                        severity=rule["severity"],
+                        code=rule["code"],
+                    )
+                )
+
+        # DFT group present but DFTTYP not set in CONTRL
+        dft_group = parsed_input.get_group("DFT")
+        if dft_group and not contrl_kws.get("DFTTYP"):
+            diagnostics.append(
+                SemanticDiagnostic(
+                    line=dft_group.line_start,
+                    message="存在 $DFT 组但未设置 DFTTYP。请在 $CONTRL 中设置 DFTTYP 以启用 DFT 计算。",
+                    severity="warning",
+                    code="DFT_GROUP_NO_DFTTYP",
+                )
+            )
+
+        # MP2 group present but MPLEVL not set to 2
+        mp2_group = parsed_input.get_group("MP2")
+        if mp2_group and contrl_kws.get("MPLEVL") != "2":
+            diagnostics.append(
+                SemanticDiagnostic(
+                    line=mp2_group.line_start,
+                    message="存在 $MP2 组但未设置 MPLEVL=2。请在 $CONTRL 中设置 MPLEVL=2 以启用 MP2 计算。",
+                    severity="warning",
+                    code="MP2_GROUP_NO_MPLEVL",
+                )
+            )
+
+        return diagnostics
+
+    def _validate_runtyp_method(
+        self, contrl: GAMESSGroup, contrl_kws: Dict[str, str]
+    ) -> List[SemanticDiagnostic]:
+        """Validate that RUNTYP is compatible with selected method."""
+        diagnostics = []
+
+        runtyp = contrl_kws.get("RUNTYP", "ENERGY")
+
+        for rule in self.RUNTYP_METHOD_CONSTRAINTS:
+            if runtyp != rule["runtyp"]:
+                continue
+            for kw_name, kw_value in rule["forbidden_kws"].items():
+                actual = contrl_kws.get(kw_name)
+                if actual is None:
+                    continue
+                if kw_value is True:
+                    # Any value triggers the conflict
+                    diagnostics.append(
+                        SemanticDiagnostic(
+                            line=contrl.line_start,
+                            message=rule["message"],
+                            severity=rule["severity"],
+                            code=rule["code"],
+                        )
+                    )
+                elif actual == kw_value:
+                    diagnostics.append(
+                        SemanticDiagnostic(
+                            line=contrl.line_start,
+                            message=rule["message"],
+                            severity=rule["severity"],
+                            code=rule["code"],
+                        )
+                    )
 
         return diagnostics
 

--- a/tests/test_semantic_validation.py
+++ b/tests/test_semantic_validation.py
@@ -364,3 +364,275 @@ H     1.0   0.0   0.74  0.0
         # MULT=2 is correct for 1 unpaired electron
         codes = [d.code for d in diagnostics]
         assert "ELECTRON_MULT_MISMATCH" not in codes
+
+
+class TestMutualExclusivity:
+    """Tests for mutually exclusive parameter detection (issue #6)."""
+
+    def test_mp2_with_ci_is_error(self):
+        """MPLEVL=2 with CITYP is incompatible."""
+        content = """
+ $CONTRL MPLEVL=2 CITYP=GUGA RUNTYP=ENERGY $END
+ $BASIS GBASIS=STO NGAUSS=3 $END
+ $DATA
+Test
+C1
+H     1.0   0.0   0.0   0.0
+ $END
+"""
+        parser = GAMESSParser()
+        parsed = parser.parse(content)
+        diagnostics = validate_semantics(parsed)
+
+        codes = [d.code for d in diagnostics]
+        assert "INCOMPAT_MP2_CI" in codes
+
+        diag = next(d for d in diagnostics if d.code == "INCOMPAT_MP2_CI")
+        assert diag.severity == "error"
+
+    def test_cc_with_ci_is_error(self):
+        """CCTYP with CITYP is incompatible."""
+        content = """
+ $CONTRL CCTYP=CCSD(T) CITYP=GUGA RUNTYP=ENERGY $END
+ $BASIS GBASIS=CC-PVDZ $END
+ $DATA
+Test
+C1
+H     1.0   0.0   0.0   0.0
+ $END
+"""
+        parser = GAMESSParser()
+        parsed = parser.parse(content)
+        diagnostics = validate_semantics(parsed)
+
+        codes = [d.code for d in diagnostics]
+        assert "INCOMPAT_CC_CI" in codes
+
+    def test_dft_with_ci_is_error(self):
+        """DFTTYP with CITYP is incompatible."""
+        content = """
+ $CONTRL DFTTYP=B3LYP CITYP=CIS RUNTYP=ENERGY $END
+ $BASIS GBASIS=CC-PVDZ $END
+ $DATA
+Test
+C1
+H     1.0   0.0   0.0   0.0
+ $END
+"""
+        parser = GAMESSParser()
+        parsed = parser.parse(content)
+        diagnostics = validate_semantics(parsed)
+
+        codes = [d.code for d in diagnostics]
+        assert "INCOMPAT_DFT_CI" in codes
+
+    def test_rohf_with_mp2_is_error(self):
+        """ROHF reference is incompatible with MP2."""
+        content = """
+ $CONTRL SCFTYP=ROHF MPLEVL=2 RUNTYP=ENERGY $END
+ $BASIS GBASIS=CC-PVDZ $END
+ $DATA
+Test
+C1
+O     8.0   0.0   0.0   0.0
+ $END
+"""
+        parser = GAMESSParser()
+        parsed = parser.parse(content)
+        diagnostics = validate_semantics(parsed)
+
+        codes = [d.code for d in diagnostics]
+        assert "INCOMPAT_ROHF_MP2" in codes
+
+        diag = next(d for d in diagnostics if d.code == "INCOMPAT_ROHF_MP2")
+        assert diag.severity == "error"
+
+    def test_valid_mp2_calculation_no_ci(self):
+        """Valid MP2 calculation without CI should pass."""
+        content = """
+ $CONTRL SCFTYP=RHF MPLEVL=2 RUNTYP=ENERGY $END
+ $BASIS GBASIS=CC-PVDZ $END
+ $DATA
+Test
+C1
+H     1.0   0.0   0.0   0.0
+H     1.0   0.0   0.74  0.0
+ $END
+"""
+        parser = GAMESSParser()
+        parsed = parser.parse(content)
+        diagnostics = validate_semantics(parsed)
+
+        codes = [d.code for d in diagnostics]
+        assert "INCOMPAT_MP2_CI" not in codes
+        assert "INCOMPAT_ROHF_MP2" not in codes
+
+    def test_valid_ci_calculation(self):
+        """Valid CI calculation without post-HF should pass."""
+        content = """
+ $CONTRL SCFTYP=RHF CITYP=CIS RUNTYP=ENERGY $END
+ $BASIS GBASIS=CC-PVDZ $END
+ $DATA
+Test
+C1
+H     1.0   0.0   0.0   0.0
+H     1.0   0.0   0.74  0.0
+ $END
+"""
+        parser = GAMESSParser()
+        parsed = parser.parse(content)
+        diagnostics = validate_semantics(parsed)
+
+        # No post-HF conflict errors
+        conflict_codes = [c for c in ["INCOMPAT_MP2_CI", "INCOMPAT_CC_CI", "INCOMPAT_DFT_CI"]
+                          if c in [d.code for d in diagnostics]]
+        assert len(conflict_codes) == 0
+
+
+class TestCrossGroupConflicts:
+    """Tests for cross-group conflict detection (issue #6)."""
+
+    def test_scf_and_mcscf_groups_conflict(self):
+        """Both $SCF and $MCSCF groups present with SCFTYP=MCSCF triggers warning."""
+        content = """
+ $CONTRL SCFTYP=MCSCF RUNTYP=ENERGY $END
+ $SCF DIRSCF=.TRUE. $END
+ $MCSCF CISTEP=ALDET $END
+ $BASIS GBASIS=CC-PVDZ $END
+ $DATA
+Test
+C1
+H     1.0   0.0   0.0   0.0
+ $END
+"""
+        parser = GAMESSParser()
+        parsed = parser.parse(content)
+        diagnostics = validate_semantics(parsed)
+
+        codes = [d.code for d in diagnostics]
+        assert "CONFLICT_SCF_MCSCF" in codes
+
+    def test_dft_group_without_dfttyp(self):
+        """$DFT group present without DFTTYP in CONTRL triggers warning."""
+        content = """
+ $CONTRL SCFTYP=RHF RUNTYP=ENERGY $END
+ $BASIS GBASIS=CC-PVDZ $END
+ $DFT NRAD=96 NLEB=302 $END
+ $DATA
+Test
+C1
+H     1.0   0.0   0.0   0.0
+H     1.0   0.0   0.74  0.0
+ $END
+"""
+        parser = GAMESSParser()
+        parsed = parser.parse(content)
+        diagnostics = validate_semantics(parsed)
+
+        codes = [d.code for d in diagnostics]
+        assert "DFT_GROUP_NO_DFTTYP" in codes
+
+        diag = next(d for d in diagnostics if d.code == "DFT_GROUP_NO_DFTTYP")
+        assert diag.severity == "warning"
+
+    def test_mp2_group_without_mplevl(self):
+        """$MP2 group present without MPLEVL=2 in CONTRL triggers warning."""
+        content = """
+ $CONTRL SCFTYP=RHF RUNTYP=ENERGY $END
+ $BASIS GBASIS=CC-PVDZ $END
+ $MP2 NACORE=0 $END
+ $DATA
+Test
+C1
+H     1.0   0.0   0.0   0.0
+H     1.0   0.0   0.74  0.0
+ $END
+"""
+        parser = GAMESSParser()
+        parsed = parser.parse(content)
+        diagnostics = validate_semantics(parsed)
+
+        codes = [d.code for d in diagnostics]
+        assert "MP2_GROUP_NO_MPLEVL" in codes
+
+        diag = next(d for d in diagnostics if d.code == "MP2_GROUP_NO_MPLEVL")
+        assert diag.severity == "warning"
+
+    def test_dft_group_with_dfttyp_is_valid(self):
+        """$DFT group with DFTTYP set should not warn."""
+        content = """
+ $CONTRL SCFTYP=RHF DFTTYP=B3LYP RUNTYP=ENERGY $END
+ $BASIS GBASIS=CC-PVDZ $END
+ $DFT NRAD=96 NLEB=302 $END
+ $DATA
+Test
+C1
+H     1.0   0.0   0.0   0.0
+H     1.0   0.0   0.74  0.0
+ $END
+"""
+        parser = GAMESSParser()
+        parsed = parser.parse(content)
+        diagnostics = validate_semantics(parsed)
+
+        codes = [d.code for d in diagnostics]
+        assert "DFT_GROUP_NO_DFTTYP" not in codes
+
+
+class TestRuntypMethodConstraints:
+    """Tests for RUNTYP vs method compatibility (issue #6)."""
+
+    def test_surface_with_cc_is_error(self):
+        """RUNTYP=SURFACE with CCTYP is incompatible."""
+        content = """
+ $CONTRL SCFTYP=RHF CCTYP=CCSD(T) RUNTYP=SURFACE $END
+ $BASIS GBASIS=CC-PVDZ $END
+ $DATA
+Test
+C1
+H     1.0   0.0   0.0   0.0
+ $END
+"""
+        parser = GAMESSParser()
+        parsed = parser.parse(content)
+        diagnostics = validate_semantics(parsed)
+
+        codes = [d.code for d in diagnostics]
+        assert "INCOMPAT_SURFACE_CC" in codes
+
+    def test_drc_with_mp2_is_error(self):
+        """RUNTYP=DRC with MPLEVL=2 is incompatible."""
+        content = """
+ $CONTRL SCFTYP=RHF MPLEVL=2 RUNTYP=DRC $END
+ $BASIS GBASIS=STO NGAUSS=3 $END
+ $DATA
+Test
+C1
+H     1.0   0.0   0.0   0.0
+ $END
+"""
+        parser = GAMESSParser()
+        parsed = parser.parse(content)
+        diagnostics = validate_semantics(parsed)
+
+        codes = [d.code for d in diagnostics]
+        assert "INCOMPAT_DRC_MP2" in codes
+
+    def test_surface_without_cc_is_valid(self):
+        """RUNTYP=SURFACE without CC methods is valid."""
+        content = """
+ $CONTRL SCFTYP=RHF RUNTYP=SURFACE $END
+ $BASIS GBASIS=CC-PVDZ $END
+ $SURFACE NSURF=10 $END
+ $DATA
+Test
+C1
+H     1.0   0.0   0.0   0.0
+ $END
+"""
+        parser = GAMESSParser()
+        parsed = parser.parse(content)
+        diagnostics = validate_semantics(parsed)
+
+        codes = [d.code for d in diagnostics]
+        assert "INCOMPAT_SURFACE_CC" not in codes

--- a/tests/test_tokenizer.py
+++ b/tests/test_tokenizer.py
@@ -1,0 +1,68 @@
+"""Tests for the shared tokenizer utility."""
+
+from gamess_lsp.tokenizer import tokenize_line
+
+
+class TestTokenizeLine:
+    """Tests for tokenize_line function."""
+
+    def test_simple_tokens(self):
+        """Whitespace-separated tokens without quotes."""
+        assert tokenize_line("A=1 B=2 C=3") == ["A=1", "B=2", "C=3"]
+
+    def test_empty_string(self):
+        """Empty input returns empty list."""
+        assert tokenize_line("") == []
+
+    def test_whitespace_only(self):
+        """Whitespace-only input returns empty list."""
+        assert tokenize_line("   ") == []
+
+    def test_single_token(self):
+        """Single token without spaces."""
+        assert tokenize_line("KEY=VALUE") == ["KEY=VALUE"]
+
+    def test_double_quoted_value(self):
+        """Double-quoted value preserved as single token."""
+        assert tokenize_line('KEY="hello world"') == ['KEY="hello world"']
+
+    def test_single_quoted_value(self):
+        """Single-quoted value preserved as single token."""
+        assert tokenize_line("KEY='hello world'") == ["KEY='hello world'"]
+
+    def test_mixed_quoted_and_unquoted(self):
+        """Mix of quoted and unquoted tokens."""
+        result = tokenize_line('A=1 NAME="john doe" C=3')
+        assert result == ['A=1', 'NAME="john doe"', 'C=3']
+
+    def test_quoted_with_inner_spaces(self):
+        """Quoted values with multiple inner spaces."""
+        result = tokenize_line('TITLE="a  b   c"')
+        assert result == ['TITLE="a  b   c"']
+
+    def test_adjacent_quoted_values(self):
+        """Two quoted values adjacent with single space separator."""
+        result = tokenize_line('A="x" B="y"')
+        assert result == ['A="x"', 'B="y"']
+
+    def test_unclosed_quote_treated_as_quoted(self):
+        """Unclosed quote swallows remaining input into one token."""
+        result = tokenize_line('KEY="unclosed value')
+        assert result == ['KEY="unclosed value']
+
+    def test_alternating_quotes(self):
+        """Double quotes inside single-quoted value."""
+        result = tokenize_line("""MSG='say "hello"'""")
+        assert result == ["""MSG='say "hello"'"""]
+
+    def test_leading_and_trailing_whitespace(self):
+        """Leading and trailing whitespace is ignored."""
+        assert tokenize_line("  A=1 B=2  ") == ["A=1", "B=2"]
+
+    def test_multiple_spaces_between_tokens(self):
+        """Multiple spaces between tokens collapsed."""
+        assert tokenize_line("A=1   B=2") == ["A=1", "B=2"]
+
+    def test_empty_quotes_preserved(self):
+        """Empty quoted string preserved as token content."""
+        assert tokenize_line('KEY=""') == ['KEY=""']


### PR DESCRIPTION
## Summary

Closes #6

Adds validation rules for mutually exclusive GAMESS input parameters and invalid combinations.

## Changes

### New method incompatibility rules
- MP2 + CI detection (`INCOMPAT_MP2_CI`)
- CC + CI detection (`INCOMPAT_CC_CI`)
- DFT + CI detection (`INCOMPAT_DFT_CI`)
- ROHF + MP2 detection (`INCOMPAT_ROHF_MP2`)

### Cross-group conflict detection
- $SCF and $MCSCF both present with SCFTYP=MCSCF (`CONFLICT_SCF_MCSCF`)
- $DFT group without DFTTYP in $CONTRL (`DFT_GROUP_NO_DFTTYP`)
- $MP2 group without MPLEVL=2 in $CONTRL (`MP2_GROUP_NO_MPLEVL`)

### RUNTYP + method constraints
- RUNTYP=SURFACE with CCTYP (`INCOMPAT_SURFACE_CC`)
- RUNTYP=DRC with MPLEVL=2 (`INCOMPAT_DRC_MP2`)

### Tests
- 13 new diagnostic tests covering all new rules

## Test plan
- [x] All tests pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)