### PR TITLE
feat: add validation accuracy testing framework

### DIFF
--- a/tests/test_validation_framework.py
+++ b/tests/test_validation_framework.py
@@ -1,0 +1,113 @@
+"""Validation accuracy tests driven by the fixture corpus.
+
+These tests load JSON fixture files from tests/validation/ and verify
+that the validator produces the expected diagnostics for each case.
+
+This framework is designed to be extended: add new .json fixtures to
+the appropriate subdirectory and they will be automatically discovered.
+"""
+
+import json
+
+import pytest
+
+from gamess_lsp.parser import parse_gamess_input
+from gamess_lsp.validator import validate_semantics
+
+from validation.conftest import (
+    compute_accuracy_report,
+    load_fixtures,
+    run_fixture,
+)
+
+
+def _fixture_ids():
+    """Generate test IDs from fixture names."""
+    return [f.name for f in load_fixtures()]
+
+
+@pytest.fixture(params=load_fixtures(), ids=_fixture_ids())
+def fixture_case(request):
+    """Parametrized fixture providing each test case."""
+    return request.param
+
+
+class TestFixtureCorpus:
+    """Run all fixture cases from the validation corpus."""
+
+    def test_fixture(self, fixture_case):
+        """Each fixture should produce exactly the expected diagnostics."""
+        passed, mismatches = run_fixture(fixture_case)
+        assert passed, (
+            f"Fixture {fixture_case.name} failed:\n"
+            + "\n".join(f"  - {m}" for m in mismatches)
+        )
+
+
+class TestAccuracyReport:
+    """Verify that the overall accuracy meets the minimum threshold."""
+
+    def test_overall_accuracy_above_90_percent(self):
+        """Overall accuracy across all fixture categories must be >= 90%."""
+        report = compute_accuracy_report()
+        assert report.overall_accuracy >= 0.90, (
+            f"Overall accuracy {report.overall_accuracy:.2%} is below 90%.\n"
+            f"Details: {json.dumps(report.to_dict(), indent=2)}"
+        )
+
+    def test_no_empty_categories(self):
+        """Every category directory should have at least one fixture."""
+        report = compute_accuracy_report()
+        for cat_name, cat in report.categories.items():
+            assert cat.total > 0, f"Category '{cat_name}' has no fixtures"
+
+    def test_report_is_serializable(self):
+        """The accuracy report should be JSON-serializable for CI reporting."""
+        report = compute_accuracy_report()
+        data = report.to_dict()
+        json_str = json.dumps(data)
+        assert json_str
+        parsed_back = json.loads(json_str)
+        assert "total_fixtures" in parsed_back
+        assert "categories" in parsed_back
+
+
+class TestCategoryAccuracy:
+    """Per-category accuracy thresholds."""
+
+    def test_mutually_exclusive_accuracy(self):
+        """Mutually exclusive detection should be accurate."""
+        report = compute_accuracy_report()
+        cat = report.categories.get("mutually_exclusive")
+        if cat and cat.total > 0:
+            assert cat.precision >= 0.90, (
+                f"mutually_exclusive precision {cat.precision:.2%} < 90%"
+            )
+            assert cat.recall >= 0.90, (
+                f"mutually_exclusive recall {cat.recall:.2%} < 90%"
+            )
+
+    def test_chemical_constraints_accuracy(self):
+        """Chemical constraint detection should be accurate."""
+        report = compute_accuracy_report()
+        cat = report.categories.get("chemical_constraints")
+        if cat and cat.total > 0:
+            assert cat.precision >= 0.90, (
+                f"chemical_constraints precision {cat.precision:.2%} < 90%"
+            )
+            assert cat.recall >= 0.90, (
+                f"chemical_constraints recall {cat.recall:.2%} < 90%"
+            )
+
+    def test_valid_inputs_no_errors(self):
+        """Valid inputs should produce zero error-level diagnostics."""
+        fixtures = load_fixtures()
+        valid_cases = [f for f in fixtures if f.category == "valid_inputs"]
+        for case in valid_cases:
+            parsed = parse_gamess_input(case.input_text)
+            diagnostics = validate_semantics(parsed)
+            errors = [d for d in diagnostics if d.severity == "error"]
+            assert len(errors) == 0, (
+                f"Valid input fixture {case.name} produced unexpected errors: "
+                + ", ".join(d.code for d in errors)
+            )

--- a/tests/validation/__init__.py
+++ b/tests/validation/__init__.py
@@ -1,0 +1,1 @@
+"""Validation accuracy testing framework for GAMESS LSP."""

--- a/tests/validation/chemical_constraints/charged_cation_valid.json
+++ b/tests/validation/chemical_constraints/charged_cation_valid.json
@@ -1,0 +1,6 @@
+{
+  "description": "Charged cation valid",
+  "input": " $CONTRL SCFTYP=UHF ICHARG=1 MULT=2 RUNTYP=ENERGY $END\n $BASIS GBASIS=STO NGAUSS=3 $END\n $DATA\nH2+ cation\nC1\nH     1.0   0.0   0.0   0.0\nH     1.0   0.0   0.74  0.0\n $END\n",
+  "expected_diagnostics": [],
+  "category": "chemical_constraints"
+}

--- a/tests/validation/chemical_constraints/doublet_odd_electrons_valid.json
+++ b/tests/validation/chemical_constraints/doublet_odd_electrons_valid.json
@@ -1,0 +1,6 @@
+{
+  "description": "Doublet with odd electrons valid",
+  "input": " $CONTRL SCFTYP=UHF MULT=2 RUNTYP=ENERGY $END\n $BASIS GBASIS=STO NGAUSS=3 $END\n $DATA\nH atom\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [],
+  "category": "chemical_constraints"
+}

--- a/tests/validation/chemical_constraints/openshell_rhf.json
+++ b/tests/validation/chemical_constraints/openshell_rhf.json
@@ -1,0 +1,11 @@
+{
+  "description": "Open-shell with RHF",
+  "input": " $CONTRL SCFTYP=RHF MULT=2 RUNTYP=ENERGY $END\n $BASIS GBASIS=STO NGAUSS=3 $END\n $DATA\nH atom\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "OPEN_SHELL_RHF",
+      "severity": "error"
+    }
+  ],
+  "category": "chemical_constraints"
+}

--- a/tests/validation/chemical_constraints/singlet_odd_electrons.json
+++ b/tests/validation/chemical_constraints/singlet_odd_electrons.json
@@ -1,0 +1,11 @@
+{
+  "description": "Singlet with odd electron count",
+  "input": " $CONTRL SCFTYP=UHF MULT=1 RUNTYP=ENERGY $END\n $BASIS GBASIS=STO NGAUSS=3 $END\n $DATA\nH atom\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "ELECTRON_MULT_MISMATCH",
+      "severity": "error"
+    }
+  ],
+  "category": "chemical_constraints"
+}

--- a/tests/validation/conftest.py
+++ b/tests/validation/conftest.py
@@ -1,0 +1,157 @@
+"""Validation accuracy testing framework for GAMESS LSP.
+
+This module loads fixture corpora, runs the validator, and computes
+accuracy metrics (TP, FP, FN, precision, recall, F1) per category.
+
+It does NOT claim exhaustive scientific coverage. The fixture corpus
+represents a safe, tested subset of GAMESS parameter constraints.
+"""
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Tuple
+
+from gamess_lsp.parser import parse_gamess_input
+from gamess_lsp.validator import validate_semantics
+
+
+FIXTURE_ROOT = Path(__file__).parent
+
+
+@dataclass
+class FixtureCase:
+    name: str
+    category: str
+    input_text: str
+    expected_diagnostics: List[Dict[str, Any]]
+    description: str = ""
+
+
+@dataclass
+class CategoryMetrics:
+    category: str
+    total: int = 0
+    true_positives: int = 0
+    false_positives: int = 0
+    false_negatives: int = 0
+
+    @property
+    def precision(self) -> float:
+        denom = self.true_positives + self.false_positives
+        return self.true_positives / denom if denom > 0 else 1.0
+
+    @property
+    def recall(self) -> float:
+        denom = self.true_positives + self.false_negatives
+        return self.true_positives / denom if denom > 0 else 1.0
+
+    @property
+    def f1(self) -> float:
+        p, r = self.precision, self.recall
+        return 2 * p * r / (p + r) if (p + r) > 0 else 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "category": self.category,
+            "total": self.total,
+            "true_positives": self.true_positives,
+            "false_positives": self.false_positives,
+            "false_negatives": self.false_negatives,
+            "precision": round(self.precision, 4),
+            "recall": round(self.recall, 4),
+            "f1": round(self.f1, 4),
+        }
+
+
+@dataclass
+class AccuracyReport:
+    total_fixtures: int = 0
+    passed: int = 0
+    failed: int = 0
+    categories: Dict[str, CategoryMetrics] = field(default_factory=dict)
+
+    @property
+    def overall_accuracy(self) -> float:
+        return self.passed / self.total_fixtures if self.total_fixtures > 0 else 1.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "total_fixtures": self.total_fixtures,
+            "passed": self.passed,
+            "failed": self.failed,
+            "overall_accuracy": f"{self.overall_accuracy:.2%}",
+            "categories": {k: v.to_dict() for k, v in self.categories.items()},
+        }
+
+
+def load_fixtures() -> List[FixtureCase]:
+    fixtures = []
+    for category_dir in sorted(FIXTURE_ROOT.iterdir()):
+        if not category_dir.is_dir():
+            continue
+        if category_dir.name.startswith("_") or category_dir.name == "__pycache__":
+            continue
+        category = category_dir.name
+        for fixture_file in sorted(category_dir.glob("*.json")):
+            with open(fixture_file) as f:
+                data = json.load(f)
+            fixtures.append(
+                FixtureCase(
+                    name=f"{category}/{fixture_file.stem}",
+                    category=category,
+                    input_text=data["input"],
+                    expected_diagnostics=data.get("expected_diagnostics", []),
+                    description=data.get("description", ""),
+                )
+            )
+    return fixtures
+
+
+def run_fixture(case: FixtureCase) -> Tuple[bool, List[str]]:
+    parsed = parse_gamess_input(case.input_text)
+    actual = validate_semantics(parsed)
+    actual_by_code: Dict[str, List] = {}
+    for d in actual:
+        actual_by_code.setdefault(d.code, []).append(d)
+    mismatches = []
+    all_passed = True
+    for expected in case.expected_diagnostics:
+        code = expected["code"]
+        severity = expected.get("severity", "error")
+        matching = actual_by_code.get(code, [])
+        if not matching:
+            mismatches.append(f"MISSING: expected {code} ({severity}), not found")
+            all_passed = False
+        elif not any(d.severity == severity for d in matching):
+            actual_sevs = [d.severity for d in matching]
+            mismatches.append(f"WRONG SEVERITY: expected {code} ({severity}), got {actual_sevs}")
+            all_passed = False
+    if not case.expected_diagnostics and actual:
+        error_diags = [d for d in actual if d.severity == "error"]
+        if error_diags:
+            codes_str = ", ".join(d.code for d in error_diags)
+            mismatches.append(f"FALSE POSITIVE: unexpected errors: {codes_str}")
+            all_passed = False
+    return all_passed, mismatches
+
+
+def compute_accuracy_report() -> AccuracyReport:
+    fixtures = load_fixtures()
+    report = AccuracyReport()
+    category_metrics: Dict[str, CategoryMetrics] = {}
+    for case in fixtures:
+        if case.category not in category_metrics:
+            category_metrics[case.category] = CategoryMetrics(category=case.category)
+        passed, _ = run_fixture(case)
+        cat = category_metrics[case.category]
+        cat.total += 1
+        report.total_fixtures += 1
+        if passed:
+            report.passed += 1
+            cat.true_positives += 1
+        else:
+            report.failed += 1
+            cat.false_negatives += 1
+    report.categories = category_metrics
+    return report

--- a/tests/validation/cross_group/dft_group_no_dfttyp.json
+++ b/tests/validation/cross_group/dft_group_no_dfttyp.json
@@ -1,0 +1,11 @@
+{
+  "description": "$DFT group without DFTTYP",
+  "input": " $CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n $BASIS GBASIS=CC-PVDZ $END\n $DFT NRAD=96 NLEB=302 $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\nH     1.0   0.0   0.74  0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "DFT_GROUP_NO_DFTTYP",
+      "severity": "warning"
+    }
+  ],
+  "category": "cross_group"
+}

--- a/tests/validation/cross_group/mp2_group_no_mplevl.json
+++ b/tests/validation/cross_group/mp2_group_no_mplevl.json
@@ -1,0 +1,11 @@
+{
+  "description": "$MP2 group without MPLEVL=2",
+  "input": " $CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n $BASIS GBASIS=CC-PVDZ $END\n $MP2 NACORE=0 $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\nH     1.0   0.0   0.74  0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "MP2_GROUP_NO_MPLEVL",
+      "severity": "warning"
+    }
+  ],
+  "category": "cross_group"
+}

--- a/tests/validation/cross_group/scf_mcscf_conflict.json
+++ b/tests/validation/cross_group/scf_mcscf_conflict.json
@@ -1,0 +1,11 @@
+{
+  "description": "$SCF and $MCSCF with SCFTYP=MCSCF",
+  "input": " $CONTRL SCFTYP=MCSCF RUNTYP=ENERGY $END\n $SCF DIRSCF=.TRUE. $END\n $MCSCF CISTEP=ALDET $END\n $BASIS GBASIS=CC-PVDZ $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "CONFLICT_SCF_MCSCF",
+      "severity": "warning"
+    }
+  ],
+  "category": "cross_group"
+}

--- a/tests/validation/invalid_combinations/rhf_mult2.json
+++ b/tests/validation/invalid_combinations/rhf_mult2.json
@@ -1,0 +1,11 @@
+{
+  "description": "RHF with MULT=2 is invalid",
+  "input": " $CONTRL SCFTYP=RHF MULT=2 RUNTYP=ENERGY $END\n $BASIS GBASIS=STO NGAUSS=3 $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "SCFTYP_MULT_INCOMPAT",
+      "severity": "error"
+    }
+  ],
+  "category": "invalid_combinations"
+}

--- a/tests/validation/invalid_combinations/rohf_mp2.json
+++ b/tests/validation/invalid_combinations/rohf_mp2.json
@@ -1,0 +1,11 @@
+{
+  "description": "ROHF with MP2 is invalid",
+  "input": " $CONTRL SCFTYP=ROHF MPLEVL=2 RUNTYP=ENERGY $END\n $BASIS GBASIS=CC-PVDZ $END\n $DATA\nTest\nC1\nO     8.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "INCOMPAT_ROHF_MP2",
+      "severity": "error"
+    }
+  ],
+  "category": "invalid_combinations"
+}

--- a/tests/validation/invalid_combinations/rohf_mult1.json
+++ b/tests/validation/invalid_combinations/rohf_mult1.json
@@ -1,0 +1,11 @@
+{
+  "description": "ROHF with MULT=1 is invalid",
+  "input": " $CONTRL SCFTYP=ROHF MULT=1 RUNTYP=ENERGY $END\n $BASIS GBASIS=STO NGAUSS=3 $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "SCFTYP_MULT_INCOMPAT",
+      "severity": "error"
+    }
+  ],
+  "category": "invalid_combinations"
+}

--- a/tests/validation/invalid_combinations/uhf_cc_warning.json
+++ b/tests/validation/invalid_combinations/uhf_cc_warning.json
@@ -1,0 +1,11 @@
+{
+  "description": "UHF with CC is a warning",
+  "input": " $CONTRL SCFTYP=UHF CCTYP=CCSD(T) RUNTYP=ENERGY $END\n $BASIS GBASIS=CC-PVDZ $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "WARN_UHF_CC",
+      "severity": "warning"
+    }
+  ],
+  "category": "invalid_combinations"
+}

--- a/tests/validation/mutually_exclusive/cc_ci.json
+++ b/tests/validation/mutually_exclusive/cc_ci.json
@@ -1,0 +1,11 @@
+{
+  "description": "CCTYP and CITYP are mutually exclusive",
+  "input": " $CONTRL CCTYP=CCSD(T) CITYP=GUGA RUNTYP=ENERGY $END\n $BASIS GBASIS=CC-PVDZ $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "INCOMPAT_CC_CI",
+      "severity": "error"
+    }
+  ],
+  "category": "mutually_exclusive"
+}

--- a/tests/validation/mutually_exclusive/dft_cc.json
+++ b/tests/validation/mutually_exclusive/dft_cc.json
@@ -1,0 +1,11 @@
+{
+  "description": "DFTTYP and CCTYP are mutually exclusive",
+  "input": " $CONTRL SCFTYP=RHF DFTTYP=B3LYP CCTYP=CCSD(T) RUNTYP=ENERGY $END\n $BASIS GBASIS=CC-PVDZ $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "INCOMPAT_DFT_CC",
+      "severity": "error"
+    }
+  ],
+  "category": "mutually_exclusive"
+}

--- a/tests/validation/mutually_exclusive/dft_ci.json
+++ b/tests/validation/mutually_exclusive/dft_ci.json
@@ -1,0 +1,11 @@
+{
+  "description": "DFTTYP and CITYP are mutually exclusive",
+  "input": " $CONTRL DFTTYP=B3LYP CITYP=CIS RUNTYP=ENERGY $END\n $BASIS GBASIS=CC-PVDZ $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "INCOMPAT_DFT_CI",
+      "severity": "error"
+    }
+  ],
+  "category": "mutually_exclusive"
+}

--- a/tests/validation/mutually_exclusive/dft_mp2.json
+++ b/tests/validation/mutually_exclusive/dft_mp2.json
@@ -1,0 +1,11 @@
+{
+  "description": "DFTTYP and MPLEVL=2 are mutually exclusive",
+  "input": " $CONTRL SCFTYP=RHF DFTTYP=B3LYP MPLEVL=2 RUNTYP=ENERGY $END\n $BASIS GBASIS=CC-PVDZ $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "INCOMPAT_DFT_MP2",
+      "severity": "error"
+    }
+  ],
+  "category": "mutually_exclusive"
+}

--- a/tests/validation/mutually_exclusive/mp2_cc.json
+++ b/tests/validation/mutually_exclusive/mp2_cc.json
@@ -1,0 +1,11 @@
+{
+  "description": "MPLEVL=2 and CCTYP are mutually exclusive",
+  "input": " $CONTRL SCFTYP=RHF MPLEVL=2 CCTYP=CCSD(T) RUNTYP=ENERGY $END\n $BASIS GBASIS=CC-PVDZ $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\nH     1.0   0.0   0.74  0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "INCOMPAT_MP2_CC",
+      "severity": "error"
+    }
+  ],
+  "category": "mutually_exclusive"
+}

--- a/tests/validation/mutually_exclusive/mp2_ci.json
+++ b/tests/validation/mutually_exclusive/mp2_ci.json
@@ -1,0 +1,11 @@
+{
+  "description": "MPLEVL=2 and CITYP are mutually exclusive",
+  "input": " $CONTRL MPLEVL=2 CITYP=GUGA RUNTYP=ENERGY $END\n $BASIS GBASIS=STO NGAUSS=3 $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "INCOMPAT_MP2_CI",
+      "severity": "error"
+    }
+  ],
+  "category": "mutually_exclusive"
+}

--- a/tests/validation/mutually_exclusive/rohf_dft_warning.json
+++ b/tests/validation/mutually_exclusive/rohf_dft_warning.json
@@ -1,0 +1,11 @@
+{
+  "description": "ROHF-DFT is not recommended (warning)",
+  "input": " $CONTRL SCFTYP=ROHF DFTTYP=B3LYP RUNTYP=ENERGY $END\n $BASIS GBASIS=CC-PVDZ $END\n $DATA\nTest\nC1\nO     8.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "WARN_ROHF_DFT",
+      "severity": "warning"
+    }
+  ],
+  "category": "mutually_exclusive"
+}

--- a/tests/validation/runtyp_constraints/drc_mp2_invalid.json
+++ b/tests/validation/runtyp_constraints/drc_mp2_invalid.json
@@ -1,0 +1,11 @@
+{
+  "description": "RUNTYP=DRC with MPLEVL=2",
+  "input": " $CONTRL SCFTYP=RHF MPLEVL=2 RUNTYP=DRC $END\n $BASIS GBASIS=STO NGAUSS=3 $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "INCOMPAT_DRC_MP2",
+      "severity": "error"
+    }
+  ],
+  "category": "runtyp_constraints"
+}

--- a/tests/validation/runtyp_constraints/irc_missing_group.json
+++ b/tests/validation/runtyp_constraints/irc_missing_group.json
@@ -1,0 +1,11 @@
+{
+  "description": "RUNTYP=IRC without $IRC group",
+  "input": " $CONTRL SCFTYP=RHF RUNTYP=IRC $END\n $BASIS GBASIS=STO NGAUSS=3 $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "MISSING_IRC",
+      "severity": "error"
+    }
+  ],
+  "category": "runtyp_constraints"
+}

--- a/tests/validation/runtyp_constraints/optimize_missing_statpt.json
+++ b/tests/validation/runtyp_constraints/optimize_missing_statpt.json
@@ -1,0 +1,11 @@
+{
+  "description": "RUNTYP=OPTIMIZE without $STATPT",
+  "input": " $CONTRL SCFTYP=RHF RUNTYP=OPTIMIZE $END\n $BASIS GBASIS=STO NGAUSS=3 $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\nH     1.0   0.0   0.74  0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "MISSING_STATPT",
+      "severity": "warning"
+    }
+  ],
+  "category": "runtyp_constraints"
+}

--- a/tests/validation/runtyp_constraints/surface_cc_invalid.json
+++ b/tests/validation/runtyp_constraints/surface_cc_invalid.json
@@ -1,0 +1,11 @@
+{
+  "description": "RUNTYP=SURFACE with CCTYP",
+  "input": " $CONTRL SCFTYP=RHF CCTYP=CCSD(T) RUNTYP=SURFACE $END\n $BASIS GBASIS=CC-PVDZ $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\n $END\n",
+  "expected_diagnostics": [
+    {
+      "code": "INCOMPAT_SURFACE_CC",
+      "severity": "error"
+    }
+  ],
+  "category": "runtyp_constraints"
+}

--- a/tests/validation/valid_inputs/dft_optimization.json
+++ b/tests/validation/valid_inputs/dft_optimization.json
@@ -1,0 +1,6 @@
+{
+  "description": "Valid DFT B3LYP optimization",
+  "input": " $CONTRL SCFTYP=RHF DFTTYP=B3LYP RUNTYP=OPTIMIZE $END\n $BASIS GBASIS=CC-PVDZ $END\n $STATPT OPTTOL=0.0001 NSTEP=50 $END\n $DATA\nWater\nC1\nO     8.0   0.0   0.0   0.0\nH     1.0   0.7   0.7   0.0\nH     1.0  -0.7   0.7   0.0\n $END\n",
+  "expected_diagnostics": [],
+  "category": "valid_inputs"
+}

--- a/tests/validation/valid_inputs/dft_with_dft_group.json
+++ b/tests/validation/valid_inputs/dft_with_dft_group.json
@@ -1,0 +1,6 @@
+{
+  "description": "Valid DFT with DFT group",
+  "input": " $CONTRL SCFTYP=RHF DFTTYP=B3LYP RUNTYP=ENERGY $END\n $BASIS GBASIS=CC-PVDZ $END\n $DFT NRAD=96 NLEB=302 $END\n $DATA\nTest\nC1\nH     1.0   0.0   0.0   0.0\nH     1.0   0.0   0.74  0.0\n $END\n",
+  "expected_diagnostics": [],
+  "category": "valid_inputs"
+}

--- a/tests/validation/valid_inputs/mp2_energy.json
+++ b/tests/validation/valid_inputs/mp2_energy.json
@@ -1,0 +1,6 @@
+{
+  "description": "Valid MP2 energy",
+  "input": " $CONTRL SCFTYP=RHF MPLEVL=2 RUNTYP=ENERGY $END\n $BASIS GBASIS=CC-PVDZ $END\n $DATA\nH2\nC1\nH     1.0   0.0   0.0   0.0\nH     1.0   0.0   0.74  0.0\n $END\n",
+  "expected_diagnostics": [],
+  "category": "valid_inputs"
+}

--- a/tests/validation/valid_inputs/rhf_water_energy.json
+++ b/tests/validation/valid_inputs/rhf_water_energy.json
@@ -1,0 +1,6 @@
+{
+  "description": "Valid RHF water energy",
+  "input": " $CONTRL SCFTYP=RHF MULT=1 RUNTYP=ENERGY $END\n $BASIS GBASIS=STO NGAUSS=3 $END\n $DATA\nWater\nC1\nO     8.0   0.0   0.0   0.0\nH     1.0   0.7   0.7   0.0\nH     1.0  -0.7   0.7   0.0\n $END\n",
+  "expected_diagnostics": [],
+  "category": "valid_inputs"
+}

--- a/tests/validation/valid_inputs/uhf_doublet.json
+++ b/tests/validation/valid_inputs/uhf_doublet.json
@@ -1,0 +1,6 @@
+{
+  "description": "Valid UHF doublet radical",
+  "input": " $CONTRL SCFTYP=UHF MULT=2 RUNTYP=ENERGY $END\n $BASIS GBASIS=CC-PVDZ $END\n $DATA\nCH3 radical\nC1\nC     6.0   0.0   0.0   0.0\nH     1.0   0.0   1.089  0.0\nH     1.0   1.027 -0.363  0.0\nH     1.0  -1.027 -0.363  0.0\n $END\n",
+  "expected_diagnostics": [],
+  "category": "valid_inputs"
+}


### PR DESCRIPTION
## Summary

Closes #7

Implements the validation accuracy testing framework with fixture corpus, metrics, and CI integration.

## Changes

### Fixture corpus (27 test cases across 6 categories)

| Category | Count | Description |
|----------|-------|-------------|
| mutually_exclusive | 7 | DFT+MP2, DFT+CC, MP2+CC, MP2+CI, CC+CI, DFT+CI, ROHF+DFT |
| invalid_combinations | 4 | ROHF+MP2, RHF+MULT2, ROHF+MULT1, UHF+CC |
| chemical_constraints | 4 | electron/mult mismatch, open-shell+RHF, cation, doublet |
| runtyp_constraints | 4 | IRC missing, OPTIMIZE missing, SURFACE+CC, DRC+MP2 |
| cross_group | 3 | SCF/MCSCF conflict, DFT group orphan, MP2 group orphan |
| valid_inputs | 5 | RHF water, DFT opt, MP2, UHF doublet, DFT with group |

### Metrics framework
- Precision, recall, F1 per category
- JSON-serializable accuracy report for CI consumption
- Overall accuracy threshold: >= 90%
- Per-category accuracy thresholds: >= 90%

### CI integration
- Framework tests run as part of the standard test suite
- Parametrized fixture discovery (add .json files, they auto-run)
- Accuracy report test blocks regression below threshold

### Coverage note
All 27 fixtures pass with 100% accuracy across all categories.
The framework does NOT claim exhaustive scientific validation coverage.
It tests a safe, well-understood subset of GAMESS parameter constraints.

## Test plan
- [x] All 246 tests pass locally (186 original + 13 PR F + 33 PR G + 14 tokenizer)
- [ ] CI green on Python 3.10, 3.11, 3.12

🤖 Generated with [Claude Code](https://claude.com/claude-code)