### PR TITLE
feat(lsp): expose live diagnostics snapshots for agent feedback loops

### DIFF
--- a/src/gamess_lsp/features/__init__.py
+++ b/src/gamess_lsp/features/__init__.py
@@ -1,0 +1,1 @@
+"""LSP feature providers for GAMESS Language Server."""

--- a/src/gamess_lsp/features/diagnostic.py
+++ b/src/gamess_lsp/features/diagnostic.py
@@ -1,0 +1,269 @@
+"""LSP diagnostic provider for GAMESS input files.
+
+Exposes live diagnostics snapshots suitable for both LSP clients and
+machine-readable agent feedback loops.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import asdict
+from typing import Any
+
+from lsprotocol.types import (
+    Diagnostic,
+    DiagnosticSeverity,
+    Position,
+    Range,
+)
+from pygls.server import LanguageServer
+
+from ..keywords import GAMESS_GROUPS, GAMESS_KEYWORDS
+from ..parser import GAMESSParser
+from ..validator import SemanticDiagnostic, validate_semantics
+
+_DIAGNOSTIC_SOURCE = "gamess-lsp"
+
+
+class DiagnosticProvider:
+    """Provider for GAMESS diagnostics.
+
+    Parses a document, runs syntax and semantic validation, and returns
+    a deterministic list of ``Diagnostic`` objects.  Also exposes a
+    CLI-friendly ``snapshot`` method that returns JSON-serialisable
+    diagnostic payloads for agent feedback loops.
+    """
+
+    def __init__(self, server: LanguageServer) -> None:
+        """Initialize diagnostic provider.
+
+        Args:
+            server: The language server instance.
+        """
+        self.server = server
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_diagnostics(self, text: str) -> list[Diagnostic]:
+        """Get LSP diagnostics for *text*.
+
+        Args:
+            text: Full document text.
+
+        Returns:
+            Deterministic list of ``Diagnostic`` objects sorted by line
+            then severity then message.
+        """
+        raw = self._collect_diagnostics(text)
+        return self._sort_diagnostics(raw)
+
+    def snapshot(self, uri: str, text: str) -> dict[str, Any]:
+        """Return a JSON-serialisable diagnostics snapshot.
+
+        Suitable for agent feedback loops and CLI tooling that need
+        machine-readable diagnostics without going through the LSP wire
+        protocol.
+
+        Args:
+            uri: Document URI (included verbatim in the snapshot).
+            text: Full document text.
+
+        Returns:
+            A dict with keys ``uri``, ``version``, and ``diagnostics``.
+        """
+        diagnostics = self.get_diagnostics(text)
+        return {
+            "uri": uri,
+            "version": 1,
+            "diagnostics": [_diagnostic_to_dict(d) for d in diagnostics],
+        }
+
+    def snapshot_json(self, uri: str, text: str) -> str:
+        """Return the snapshot as a JSON string.
+
+        Args:
+            uri: Document URI.
+            text: Full document text.
+
+        Returns:
+            Deterministic JSON string.
+        """
+        return json.dumps(self.snapshot(uri, text), indent=2, sort_keys=True)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _collect_diagnostics(self, text: str) -> list[Diagnostic]:
+        """Run syntax and semantic validation, returning raw diagnostics."""
+        diagnostics: list[Diagnostic] = []
+
+        # 1. Syntax-level diagnostics from parser
+        parser = GAMESSParser()
+        parsed_input = parser.parse(text)
+
+        for item in parser.get_diagnostics():
+            severity = DiagnosticSeverity.Warning
+            if item.get("severity") == "error":
+                severity = DiagnosticSeverity.Error
+
+            line = item.get("line", 1) - 1  # 0-based
+            diagnostics.append(
+                Diagnostic(
+                    range=Range(
+                        start=Position(line=line, character=0),
+                        end=Position(line=line, character=100),
+                    ),
+                    message=item.get("message", ""),
+                    severity=severity,
+                    source=_DIAGNOSTIC_SOURCE,
+                )
+            )
+
+        # 2. Semantic-level diagnostics from validator
+        semantic_diagnostics = validate_semantics(parsed_input)
+        for diag in semantic_diagnostics:
+            severity = DiagnosticSeverity.Warning
+            if diag.severity == "error":
+                severity = DiagnosticSeverity.Error
+
+            line = diag.line - 1  # Convert to 0-based
+            diagnostics.append(
+                Diagnostic(
+                    range=Range(
+                        start=Position(line=line, character=0),
+                        end=Position(line=line, character=100),
+                    ),
+                    message=diag.message,
+                    severity=severity,
+                    source=_DIAGNOSTIC_SOURCE,
+                    code=diag.code,
+                )
+            )
+
+        # 3. Keyword-level validation against known keywords
+        self._validate_keywords(parsed_input, diagnostics)
+
+        return diagnostics
+
+    def _validate_keywords(
+        self,
+        parsed_input: Any,
+        diagnostics: list[Diagnostic],
+    ) -> None:
+        """Validate keyword values against the known keyword database.
+
+        Checks for unknown keywords and invalid values within known
+        groups.
+        """
+        for group_name, group in parsed_input.groups.items():
+            known_keywords = GAMESS_KEYWORDS.get(group_name, {})
+
+            for kw_name, keyword in group.keywords.items():
+                kw_upper = kw_name.upper()
+
+                # Skip $DATA and other non-keyword groups
+                if group_name in ("DATA", "LIBRARY"):
+                    continue
+
+                # Check for unknown keyword in a known group
+                if known_keywords and kw_upper not in known_keywords:
+                    line = keyword.line_number - 1  # 0-based
+                    diagnostics.append(
+                        Diagnostic(
+                            range=Range(
+                                start=Position(line=line, character=0),
+                                end=Position(line=line, character=len(kw_name)),
+                            ),
+                            message=f"Unknown keyword '{kw_name}' in ${group_name}",
+                            severity=DiagnosticSeverity.Warning,
+                            source=_DIAGNOSTIC_SOURCE,
+                            code="UNKNOWN_KEYWORD",
+                        )
+                    )
+                    continue
+
+                # Validate value if the keyword has a restricted value set
+                if kw_upper in known_keywords:
+                    kw_info = known_keywords[kw_upper]
+                    allowed_values = kw_info.get("values", [])
+                    if allowed_values:
+                        value_upper = keyword.value.upper()
+                        if value_upper not in [v.upper() for v in allowed_values]:
+                            line = keyword.line_number - 1  # 0-based
+                            diagnostics.append(
+                                Diagnostic(
+                                    range=Range(
+                                        start=Position(line=line, character=0),
+                                        end=Position(
+                                            line=line,
+                                            character=len(keyword.value),
+                                        ),
+                                    ),
+                                    message=(
+                                        f"Invalid value '{keyword.value}' for "
+                                        f"{kw_name} in ${group_name}. "
+                                        f"Allowed: {', '.join(allowed_values)}"
+                                    ),
+                                    severity=DiagnosticSeverity.Error,
+                                    source=_DIAGNOSTIC_SOURCE,
+                                    code="INVALID_VALUE",
+                                )
+                            )
+
+    @staticmethod
+    def _sort_diagnostics(diagnostics: list[Diagnostic]) -> list[Diagnostic]:
+        """Sort diagnostics deterministically for stable output.
+
+        Order: line (asc), severity (error < warning < info), message (asc).
+        """
+        return sorted(
+            diagnostics,
+            key=lambda d: (
+                d.range.start.line,
+                d.severity if d.severity is not None else 0,
+                d.message,
+            ),
+        )
+
+
+# ------------------------------------------------------------------
+# Serialisation helpers
+# ------------------------------------------------------------------
+
+_SEVERITY_MAP = {
+    DiagnosticSeverity.Error: "error",
+    DiagnosticSeverity.Warning: "warning",
+    DiagnosticSeverity.Information: "information",
+    DiagnosticSeverity.Hint: "hint",
+}
+
+
+def _diagnostic_to_dict(diag: Diagnostic) -> dict[str, Any]:
+    """Convert a ``Diagnostic`` to a JSON-friendly dict."""
+    severity = _SEVERITY_MAP.get(
+        diag.severity,
+        "information",
+    ) if diag.severity else "information"
+
+    return {
+        "range": {
+            "start": {
+                "line": diag.range.start.line,
+                "character": diag.range.start.character,
+            },
+            "end": {
+                "line": diag.range.end.line,
+                "character": diag.range.end.character,
+            },
+        },
+        "severity": severity,
+        "source": diag.source or _DIAGNOSTIC_SOURCE,
+        "code": str(diag.code) if diag.code is not None else None,
+        "message": diag.message,
+    }
+
+
+__all__ = ["DiagnosticProvider"]

--- a/src/gamess_lsp/server.py
+++ b/src/gamess_lsp/server.py
@@ -42,6 +42,7 @@ from lsprotocol.types import (
 from pygls.server import LanguageServer
 from pygls.workspace import Document
 
+from .features.diagnostic import DiagnosticProvider
 from .keywords import GAMESS_GROUPS, GAMESS_KEYWORDS
 from .parser import GAMESSParser
 from .tokenizer import tokenize_line
@@ -108,6 +109,9 @@ class DocumentCache:
 
 # Create document cache instance
 document_cache = DocumentCache()
+
+# Create diagnostic provider instance
+diagnostic_provider = DiagnosticProvider(server)
 
 
 def _is_valid_document_uri(uri: str) -> bool:
@@ -376,7 +380,7 @@ def _update_document(doc: Document) -> None:
     content = doc.source
     document_cache.set(doc.uri, content)
 
-    diagnostics = _get_diagnostics(content)
+    diagnostics = diagnostic_provider.get_diagnostics(content)
     server.publish_diagnostics(doc.uri, diagnostics)
 
 
@@ -539,7 +543,7 @@ def _get_word_at_position(line: str, character: int) -> str:
 def diagnostic(params: Any) -> List[Diagnostic]:
     """Handle diagnostic requests."""
     doc = server.workspace.get_text_document(params.text_document.uri)
-    return _get_diagnostics(doc.source)
+    return diagnostic_provider.get_diagnostics(doc.source)
 
 
 @server.feature("textDocument/formatting")

--- a/tests/features/__init__.py
+++ b/tests/features/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for diagnostic provider."""

--- a/tests/features/test_diagnostic.py
+++ b/tests/features/test_diagnostic.py
@@ -1,0 +1,268 @@
+"""Tests for the DiagnosticProvider feature.
+
+Covers empty input, valid input, warning-level diagnostics, error-level
+diagnostics, and JSON-serialisable snapshot determinism.
+"""
+
+import json
+
+import pytest
+
+from gamess_lsp.features.diagnostic import DiagnosticProvider
+
+
+@pytest.fixture
+def provider() -> DiagnosticProvider:
+    """Create a DiagnosticProvider with a minimal LanguageServer."""
+    from pygls.server import LanguageServer
+
+    server = LanguageServer("test", "1.0")
+    return DiagnosticProvider(server)
+
+
+# ------------------------------------------------------------------
+# Provider instantiation
+# ------------------------------------------------------------------
+
+
+class TestProviderExists:
+    """Sanity checks that the provider can be created."""
+
+    def test_provider_not_none(self, provider: DiagnosticProvider) -> None:
+        assert provider is not None
+
+    def test_provider_has_server(self, provider: DiagnosticProvider) -> None:
+        assert provider.server is not None
+
+
+# ------------------------------------------------------------------
+# Empty / minimal input
+# ------------------------------------------------------------------
+
+
+class TestEmptyInput:
+    """Diagnostics for empty or blank documents."""
+
+    def test_empty_string_no_diagnostics(self, provider: DiagnosticProvider) -> None:
+        diagnostics = provider.get_diagnostics("")
+        assert isinstance(diagnostics, list)
+        assert len(diagnostics) == 0
+
+    def test_whitespace_only_no_diagnostics(self, provider: DiagnosticProvider) -> None:
+        diagnostics = provider.get_diagnostics("   \n  \n")
+        assert len(diagnostics) == 0
+
+    def test_comment_only_no_diagnostics(self, provider: DiagnosticProvider) -> None:
+        diagnostics = provider.get_diagnostics("! This is a comment\n")
+        assert len(diagnostics) == 0
+
+
+# ------------------------------------------------------------------
+# Valid input (no diagnostics expected)
+# ------------------------------------------------------------------
+
+
+class TestValidInput:
+    """Valid GAMESS input should produce no diagnostics."""
+
+    def test_valid_contrl(self, provider: DiagnosticProvider) -> None:
+        text = "$CONTRL\n SCFTYP=RHF RUNTYP=ENERGY\n $END"
+        diagnostics = provider.get_diagnostics(text)
+        assert isinstance(diagnostics, list)
+        assert len(diagnostics) == 0
+
+    def test_valid_multi_group(self, provider: DiagnosticProvider) -> None:
+        text = (
+            "$CONTRL\n SCFTYP=RHF RUNTYP=ENERGY\n $END\n"
+            "$SYSTEM\n MWORDS=100\n $END\n"
+            "$BASIS\n GBASIS=STO NGAUSS=3\n $END\n"
+        )
+        diagnostics = provider.get_diagnostics(text)
+        assert isinstance(diagnostics, list)
+        assert len(diagnostics) == 0
+
+    def test_valid_full_calculation(self, provider: DiagnosticProvider) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF DFTTYP=B3LYP RUNTYP=OPTIMIZE $END\n"
+            "$SYSTEM MWORDS=100 $END\n"
+            "$BASIS GBASIS=CC-PVDZ $END\n"
+            "$STATPT OPTTOL=0.0001 NSTEP=50 $END\n"
+            "$DATA\n"
+            "Water molecule\n"
+            "C1\n"
+            "\n"
+            "O     8.0   0.000000   0.000000   0.117489\n"
+            "H     1.0   0.000000   0.757210  -0.469957\n"
+            "H     1.0   0.000000  -0.757210  -0.469957\n"
+            " $END\n"
+        )
+        diagnostics = provider.get_diagnostics(text)
+        assert isinstance(diagnostics, list)
+        # No errors expected for valid input
+        errors = [d for d in diagnostics if d.severity == 1]  # Error = 1
+        assert len(errors) == 0
+
+
+# ------------------------------------------------------------------
+# Warning-level diagnostics
+# ------------------------------------------------------------------
+
+
+class TestWarningDiagnostics:
+    """Tests for warning-severity diagnostics."""
+
+    def test_unknown_group_warning(self, provider: DiagnosticProvider) -> None:
+        text = "$UNKNOWN $END"
+        diagnostics = provider.get_diagnostics(text)
+        assert len(diagnostics) >= 1
+        messages = [d.message for d in diagnostics]
+        assert any("Unknown group" in m for m in messages)
+
+    def test_unclosed_group_warning(self, provider: DiagnosticProvider) -> None:
+        text = "$CONTRL SCFTYP=RHF"
+        diagnostics = provider.get_diagnostics(text)
+        messages = [d.message for d in diagnostics]
+        assert any("not properly closed" in m for m in messages)
+
+    def test_unknown_keyword_warning(self, provider: DiagnosticProvider) -> None:
+        text = "$CONTRL SCFTYP=RHF BOGUSKEY=TRUE $END"
+        diagnostics = provider.get_diagnostics(text)
+        messages = [d.message for d in diagnostics]
+        assert any("Unknown keyword" in m for m in messages)
+
+
+# ------------------------------------------------------------------
+# Error-level diagnostics
+# ------------------------------------------------------------------
+
+
+class TestErrorDiagnostics:
+    """Tests for error-severity diagnostics."""
+
+    def test_invalid_contrl_value(self, provider: DiagnosticProvider) -> None:
+        text = "$CONTRL SCFTYP=INVALID $END"
+        diagnostics = provider.get_diagnostics(text)
+        messages = [d.message for d in diagnostics]
+        assert any("Invalid value" in m for m in messages)
+
+    def test_incompatible_dft_mp2(self, provider: DiagnosticProvider) -> None:
+        """DFTTYP and MPLEVL=2 are mutually exclusive."""
+        text = "$CONTRL SCFTYP=RHF DFTTYP=B3LYP MPLEVL=2 $END"
+        diagnostics = provider.get_diagnostics(text)
+        messages = [d.message for d in diagnostics]
+        assert any("DFT" in m and "MP2" in m for m in messages)
+
+    def test_incompatible_dft_cc(self, provider: DiagnosticProvider) -> None:
+        """DFTTYP and CCTYP are mutually exclusive."""
+        text = "$CONTRL SCFTYP=RHF DFTTYP=B3LYP CCTYP=CCSD $END"
+        diagnostics = provider.get_diagnostics(text)
+        messages = [d.message for d in diagnostics]
+        assert any("DFT" in m and "Coupled Cluster" in m for m in messages)
+
+    def test_invalid_basis_value(self, provider: DiagnosticProvider) -> None:
+        text = "$BASIS GBASIS=INVALID $END"
+        diagnostics = provider.get_diagnostics(text)
+        messages = [d.message for d in diagnostics]
+        assert any("Invalid value" in m and "GBASIS" in m for m in messages)
+
+
+# ------------------------------------------------------------------
+# Snapshot (JSON serialisation)
+# ------------------------------------------------------------------
+
+
+class TestSnapshot:
+    """Tests for the snapshot/snapshot_json methods."""
+
+    def test_snapshot_structure(self, provider: DiagnosticProvider) -> None:
+        snap = provider.snapshot("file:///test.inp", "$CONTRL SCFTYP=RHF $END")
+        assert "uri" in snap
+        assert "version" in snap
+        assert "diagnostics" in snap
+        assert snap["uri"] == "file:///test.inp"
+        assert isinstance(snap["diagnostics"], list)
+
+    def test_snapshot_empty_diagnostics(self, provider: DiagnosticProvider) -> None:
+        snap = provider.snapshot("file:///test.inp", "")
+        assert snap["diagnostics"] == []
+
+    def test_snapshot_with_diagnostics(self, provider: DiagnosticProvider) -> None:
+        snap = provider.snapshot("file:///test.inp", "$UNKNOWN $END")
+        assert len(snap["diagnostics"]) >= 1
+        diag = snap["diagnostics"][0]
+        assert "range" in diag
+        assert "severity" in diag
+        assert "source" in diag
+        assert "message" in diag
+
+    def test_snapshot_json_is_valid_json(self, provider: DiagnosticProvider) -> None:
+        json_str = provider.snapshot_json("file:///test.inp", "$CONTRL SCFTYP=RHF $END")
+        parsed = json.loads(json_str)
+        assert isinstance(parsed, dict)
+        assert "diagnostics" in parsed
+
+    def test_snapshot_deterministic(self, provider: DiagnosticProvider) -> None:
+        """Two calls with the same input must produce identical output."""
+        text = "$CONTRL SCFTYP=RHF DFTTYP=B3LYP MPLEVL=2 $END"
+        snap1 = provider.snapshot("file:///test.inp", text)
+        snap2 = provider.snapshot("file:///test.inp", text)
+        assert snap1 == snap2
+
+    def test_snapshot_json_deterministic(self, provider: DiagnosticProvider) -> None:
+        text = "$CONTRL SCFTYP=INVALID $END"
+        json1 = provider.snapshot_json("file:///test.inp", text)
+        json2 = provider.snapshot_json("file:///test.inp", text)
+        assert json1 == json2
+
+    def test_snapshot_error_has_error_severity(self, provider: DiagnosticProvider) -> None:
+        snap = provider.snapshot("file:///test.inp", "$CONTRL SCFTYP=INVALID $END")
+        severities = [d["severity"] for d in snap["diagnostics"]]
+        assert "error" in severities
+
+    def test_snapshot_warning_has_warning_severity(self, provider: DiagnosticProvider) -> None:
+        snap = provider.snapshot("file:///test.inp", "$UNKNOWN $END")
+        severities = [d["severity"] for d in snap["diagnostics"]]
+        assert "warning" in severities
+
+    def test_snapshot_code_present(self, provider: DiagnosticProvider) -> None:
+        snap = provider.snapshot("file:///test.inp", "$CONTRL SCFTYP=INVALID $END")
+        codes = [d["code"] for d in snap["diagnostics"] if d.get("code")]
+        assert len(codes) >= 1
+
+    def test_snapshot_source_is_gamess_lsp(self, provider: DiagnosticProvider) -> None:
+        snap = provider.snapshot("file:///test.inp", "$CONTRL SCFTYP=INVALID $END")
+        sources = {d["source"] for d in snap["diagnostics"]}
+        assert sources == {"gamess-lsp"}
+
+    def test_snapshot_range_structure(self, provider: DiagnosticProvider) -> None:
+        snap = provider.snapshot("file:///test.inp", "$UNKNOWN $END")
+        for diag in snap["diagnostics"]:
+            rng = diag["range"]
+            assert "start" in rng
+            assert "end" in rng
+            assert "line" in rng["start"]
+            assert "character" in rng["start"]
+
+
+# ------------------------------------------------------------------
+# Diagnostics sorting / determinism
+# ------------------------------------------------------------------
+
+
+class TestDeterminism:
+    """Ensure diagnostics ordering is deterministic."""
+
+    def test_multiple_diagnostics_sorted(self, provider: DiagnosticProvider) -> None:
+        """Diagnostics from multiple sources must be consistently ordered."""
+        text = (
+            "$CONTRL SCFTYP=RHF DFTTYP=B3LYP MPLEVL=2 RUNTYP=IRC $END\n"
+            "$UNKNOWN $END\n"
+        )
+        d1 = provider.get_diagnostics(text)
+        d2 = provider.get_diagnostics(text)
+        # Must produce the same list each time
+        assert len(d1) == len(d2)
+        for a, b in zip(d1, d2):
+            assert a.range.start.line == b.range.start.line
+            assert a.message == b.message
+            assert a.severity == b.severity


### PR DESCRIPTION
Implements #39 — exposes machine-readable diagnostics snapshots for agent feedback loops.

## Changes
- Add `DiagnosticProvider` class in `src/gamess_lsp/features/diagnostic.py` that validates GAMESS input files using the existing parser and semantic validator
- Add keyword-level validation against the known keyword database (unknown keywords, invalid values)
- Wire diagnostics into LSP server lifecycle (`did_open`, `did_change`, `textDocument/diagnostic`)
- Add `snapshot()` and `snapshot_json()` methods for CLI-friendly JSON-serializable diagnostic payloads
- Add comprehensive test suite (27 tests) covering empty, warning, error, snapshot, and determinism cases

## Testing
- All 273 tests pass (27 new + 246 existing, zero regressions)
- `pytest tests/ -v` passes with full coverage

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>