### PR TITLE
feat(typecheck): validate GAMESS keyword types and values

### DIFF
--- a/src/gamess_lsp/features/diagnostic.py
+++ b/src/gamess_lsp/features/diagnostic.py
@@ -21,6 +21,7 @@ from pygls.server import LanguageServer
 from ..keywords import GAMESS_GROUPS, GAMESS_KEYWORDS
 from ..parser import GAMESSParser
 from ..validator import SemanticDiagnostic, validate_semantics
+from .typecheck import TypecheckProvider
 
 _DIAGNOSTIC_SOURCE = "gamess-lsp"
 
@@ -146,6 +147,10 @@ class DiagnosticProvider:
         # 3. Keyword-level validation against known keywords
         self._validate_keywords(parsed_input, diagnostics)
 
+
+        # 4. Typecheck diagnostics (enum, type, required sections)
+        typecheck_provider = TypecheckProvider()
+        diagnostics.extend(typecheck_provider.validate(parsed_input))
         return diagnostics
 
     def _validate_keywords(

--- a/src/gamess_lsp/features/typecheck.py
+++ b/src/gamess_lsp/features/typecheck.py
@@ -1,0 +1,451 @@
+"""Type-checking validation for GAMESS keyword values.
+
+Validates keyword value types (integer, float, boolean, enum, string),
+checks enum membership against the keyword database, validates units where
+applicable, and reports missing required sections.
+
+Produces LSP ``Diagnostic`` objects with ``source="gamess-lsp-typecheck"``
+so that typecheck diagnostics are clearly distinguishable from syntax and
+semantic diagnostics.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from lsprotocol.types import (
+    Diagnostic,
+    DiagnosticSeverity,
+    Position,
+    Range,
+)
+
+from ..keywords import GAMESS_KEYWORDS
+from ..parser import GAMESSInputFile, GAMESSKeyword
+
+_DIAGNOSTIC_SOURCE = "gamess-lsp-typecheck"
+
+# ---------------------------------------------------------------------------
+# Type metadata for keywords that accept numeric / boolean values.
+# ---------------------------------------------------------------------------
+
+_NUMERIC_RE = re.compile(r"^[+-]?\d+(?:\.\d+)?(?:[eEdD][+-]?\d+)?$")
+_INTEGER_RE = re.compile(r"^[+-]?\d+$")
+
+# Keywords whose values must be integers.
+_INTEGER_KEYWORDS: set[tuple[str, str]] = {
+    ("CONTRL", "MAXIT"),
+    ("CONTRL", "MULT"),
+    ("CONTRL", "ICHARG"),
+    ("CONTRL", "ISPHER"),
+    ("SYSTEM", "MWORDS"),
+    ("SYSTEM", "MEMDDI"),
+    ("SYSTEM", "TIMLIM"),
+    ("BASIS", "NGAUSS"),
+    ("BASIS", "NDFUNC"),
+    ("BASIS", "NFFUNC"),
+    ("SCF", "NWORD"),
+    ("DFT", "NRAD"),
+    ("STATPT", "NSTEP"),
+    ("STATPT", "IFOLOW"),
+    ("FORCE", "ANHALG"),
+    ("CC", "NCORE"),
+    ("CC", "MAXCC"),
+    ("CIS", "NSTATE"),
+    ("CIS", "IROOT"),
+    ("TDDFT", "NSTATE"),
+    ("TDDFT", "IROOT"),
+    ("TDDFT", "MAXVEC"),
+    ("IRC", "NPOINT"),
+    ("DRC", "NSTEP"),
+    ("SURFACE", "NSURF"),
+    ("SURFACE", "IVEC"),
+    ("SURFACE", "NVIB"),
+    ("MCSCF", "MAXIT"),
+    ("MP2", "NACORE"),
+    ("CI", "NFZC"),
+    ("CI", "NDOC"),
+    ("CI", "NALP"),
+    ("GUESS", "NORB"),
+    ("SYSTEM", "KDIAG"),
+}
+
+# Keywords whose values must be positive integers.
+_POSITIVE_INTEGER_KEYWORDS: set[tuple[str, str]] = {
+    ("CONTRL", "MULT"),
+    ("CONTRL", "MAXIT"),
+    ("SYSTEM", "MWORDS"),
+    ("SYSTEM", "MEMDDI"),
+    ("SYSTEM", "TIMLIM"),
+    ("BASIS", "NGAUSS"),
+    ("STATPT", "NSTEP"),
+    ("CC", "MAXCC"),
+    ("CIS", "NSTATE"),
+    ("CIS", "IROOT"),
+    ("TDDFT", "NSTATE"),
+    ("TDDFT", "IROOT"),
+    ("TDDFT", "MAXVEC"),
+    ("IRC", "NPOINT"),
+    ("DRC", "NSTEP"),
+    ("MCSCF", "MAXIT"),
+}
+
+# Keywords whose values must be floats (or scientific notation).
+_FLOAT_KEYWORDS: set[tuple[str, str]] = {
+    ("CONTRL", "OPTTOL"),
+    ("SCF", "CONV"),
+    ("SCF", "ETHRSH"),
+    ("DFT", "DFTTHR"),
+    ("DFT", "LAMBDA"),
+    ("STATPT", "OPTTOL"),
+    ("STATPT", "TRMAX"),
+    ("STATPT", "TRMIN"),
+    ("FORCE", "TEMP"),
+    ("FORCE", "PRES"),
+    ("FORCE", "SCLFAC"),
+    ("CC", "CCCONV"),
+    ("TDDFT", "CVG"),
+    ("MCSCF", "ACURCY"),
+    ("IRC", "STRIDE"),
+    ("DRC", "TINIT"),
+    ("DRC", "DELTAT"),
+    ("VIB", "SCLFAC"),
+    ("PCM", "EPS"),
+    ("PCM", "RSOLV"),
+    ("COSM", "EPS"),
+    ("COSM", "RSOLV"),
+}
+
+# Keywords whose values must be GAMESS booleans (.TRUE./.FALSE./1/0).
+_BOOLEAN_KEYWORDS: set[tuple[str, str]] = {
+    ("CONTRL", "NOSYM"),
+    ("CONTRL", "EFP"),
+    ("CONTRL", "PROPS"),
+    ("BASIS", "DIFFSP"),
+    ("BASIS", "DIFFS"),
+    ("BASIS", "EXTFIL"),
+    ("SCF", "DIRSCF"),
+    ("SCF", "DIIS"),
+    ("SCF", "SOSCF"),
+    ("STATPT", "HSSEND"),
+    ("STATPT", "STPT"),
+    ("FORCE", "VIBANL"),
+    ("FORCE", "PURIFY"),
+    ("FORCE", "PROJCT"),
+    ("GUESS", "PRTMO"),
+    ("GUESS", "MIX"),
+    ("IRC", "FORWRD"),
+    ("MCSCF", "FULLNR"),
+    ("MP2", "MP2PRP"),
+    ("HESSIAN", "PRTIFC"),
+    ("HESSIAN", "VIBANL"),
+    ("ECP", "PTRAD"),
+    ("NBO", "NPA"),
+    ("SYSTEM", "PARALL"),
+}
+
+_BOOLEAN_VALUES = {".TRUE.", ".FALSE.", "1", "0"}
+
+# Unit annotations for diagnostic messages.
+_UNIT_ANNOTATIONS: dict[tuple[str, str], str] = {
+    ("SYSTEM", "MWORDS"): "million words (8 bytes each)",
+    ("SYSTEM", "MEMDDI"): "million words",
+    ("SYSTEM", "TIMLIM"): "minutes",
+    ("SCF", "CONV"): "energy change (Hartree)",
+    ("FORCE", "TEMP"): "Kelvin",
+    ("FORCE", "PRES"): "atm",
+    ("FORCE", "SCLFAC"): "dimensionless",
+    ("STATPT", "OPTTOL"): "Hartree/Bohr",
+    ("IRC", "STRIDE"): "amu^(1/2) * Bohr",
+    ("DRC", "TINIT"): "Kelvin",
+    ("DRC", "DELTAT"): "femtoseconds",
+    ("PCM", "RSOLV"): "Angstroms",
+    ("COSM", "RSOLV"): "Angstroms",
+}
+
+# Groups that are always required.
+_REQUIRED_GROUPS: list[tuple[str, str, DiagnosticSeverity]] = [
+    ("CONTRL", "$CONTRL group is required in every GAMESS input", DiagnosticSeverity.Error),
+]
+
+# Groups required depending on conditions.
+_CONDITIONALLY_REQUIRED: list[dict[str, Any]] = [
+    {
+        "condition": lambda _parsed: True,
+        "group": "DATA",
+        "message": "$DATA group is required to specify molecular geometry",
+        "severity": DiagnosticSeverity.Error,
+    },
+]
+
+
+class TypecheckProvider:
+    """Validates GAMESS keyword value types, enums, units, and required sections.
+
+    This provider is intentionally separate from the semantic validator so
+    that typecheck diagnostics carry their own ``source`` tag and can be
+    enabled/disabled independently.
+    """
+
+    def validate(self, parsed_input: GAMESSInputFile) -> list[Diagnostic]:
+        """Run typecheck validation on a parsed GAMESS input.
+
+        Args:
+            parsed_input: Parsed GAMESS input file.
+
+        Returns:
+            List of LSP Diagnostic objects with source ``gamess-lsp-typecheck``.
+        """
+        diagnostics: list[Diagnostic] = []
+
+        # 1. Required groups
+        self._check_required_groups(parsed_input, diagnostics)
+
+        # 2. Per-keyword type + enum validation
+        for group_name, group in parsed_input.groups.items():
+            known_keywords = GAMESS_KEYWORDS.get(group_name, {})
+            for kw_name, keyword in group.keywords.items():
+                kw_upper = kw_name.upper()
+                # Skip non-keyword groups
+                if group_name in ("DATA", "LIBRARY"):
+                    continue
+                # Enum validation (if the keyword has restricted values)
+                if kw_upper in known_keywords:
+                    self._check_enum(
+                        group_name, kw_upper, keyword, known_keywords[kw_upper], diagnostics
+                    )
+                # Type validation
+                self._check_type(group_name, kw_upper, keyword, diagnostics)
+
+        return diagnostics
+
+    # ------------------------------------------------------------------
+    # Required groups
+    # ------------------------------------------------------------------
+
+    def _check_required_groups(
+        self, parsed_input: GAMESSInputFile, diagnostics: list[Diagnostic]
+    ) -> None:
+        """Report missing required groups."""
+        present = set(parsed_input.groups.keys())
+
+        for group_name, message, severity in _REQUIRED_GROUPS:
+            if group_name not in present:
+                diagnostics.append(
+                    Diagnostic(
+                        range=Range(
+                            start=Position(line=0, character=0),
+                            end=Position(line=0, character=1),
+                        ),
+                        message=message,
+                        severity=severity,
+                        source=_DIAGNOSTIC_SOURCE,
+                        code="MISSING_REQUIRED_GROUP",
+                    )
+                )
+
+        for rule in _CONDITIONALLY_REQUIRED:
+            if rule["condition"](parsed_input) and rule["group"] not in present:
+                diagnostics.append(
+                    Diagnostic(
+                        range=Range(
+                            start=Position(line=0, character=0),
+                            end=Position(line=0, character=1),
+                        ),
+                        message=rule["message"],
+                        severity=rule["severity"],
+                        source=_DIAGNOSTIC_SOURCE,
+                        code="MISSING_REQUIRED_GROUP",
+                    )
+                )
+
+    # ------------------------------------------------------------------
+    # Enum validation
+    # ------------------------------------------------------------------
+
+    def _check_enum(
+        self,
+        group_name: str,
+        kw_upper: str,
+        keyword: GAMESSKeyword,
+        kw_info: dict[str, Any],
+        diagnostics: list[Diagnostic],
+    ) -> None:
+        """Validate that a keyword value is in its allowed enum set."""
+        allowed_values = kw_info.get("values", [])
+        if not allowed_values:
+            return
+
+        value_upper = keyword.value.upper()
+        allowed_upper = [v.upper() for v in allowed_values]
+        if value_upper in allowed_upper:
+            return
+
+        line = keyword.line_number - 1
+        col_start = self._value_column(keyword)
+        col_end = col_start + len(keyword.value)
+
+        diagnostics.append(
+            Diagnostic(
+                range=Range(
+                    start=Position(line=line, character=col_start),
+                    end=Position(line=line, character=col_end),
+                ),
+                message=(
+                    f"Invalid value '{keyword.value}' for {kw_upper} in "
+                    f"${group_name}. Allowed values: {', '.join(allowed_values)}"
+                ),
+                severity=DiagnosticSeverity.Error,
+                source=_DIAGNOSTIC_SOURCE,
+                code="INVALID_ENUM",
+            )
+        )
+
+    # ------------------------------------------------------------------
+    # Type validation
+    # ------------------------------------------------------------------
+
+    def _check_type(
+        self,
+        group_name: str,
+        kw_upper: str,
+        keyword: GAMESSKeyword,
+        diagnostics: list[Diagnostic],
+    ) -> None:
+        """Validate the type of a keyword value."""
+        key = (group_name, kw_upper)
+        value = keyword.value.strip()
+
+        if not value:
+            return
+
+        line = keyword.line_number - 1
+        col_start = self._value_column(keyword)
+        col_end = col_start + len(value)
+
+        # Boolean check (takes precedence)
+        if key in _BOOLEAN_KEYWORDS:
+            if value.upper() not in _BOOLEAN_VALUES:
+                diagnostics.append(
+                    Diagnostic(
+                        range=Range(
+                            start=Position(line=line, character=col_start),
+                            end=Position(line=line, character=col_end),
+                        ),
+                        message=(
+                            f"Expected boolean for {kw_upper} in ${group_name}, "
+                            f"got '{value}'. Use .TRUE. or .FALSE."
+                        ),
+                        severity=DiagnosticSeverity.Error,
+                        source=_DIAGNOSTIC_SOURCE,
+                        code="TYPE_BOOLEAN",
+                    )
+                )
+            return
+
+        # Positive integer check (stricter than general integer)
+        if key in _POSITIVE_INTEGER_KEYWORDS:
+            if not _INTEGER_RE.match(value):
+                diagnostics.append(
+                    Diagnostic(
+                        range=Range(
+                            start=Position(line=line, character=col_start),
+                            end=Position(line=line, character=col_end),
+                        ),
+                        message=(
+                            f"Expected positive integer for {kw_upper} in "
+                            f"${group_name}, got '{value}'."
+                            + self._unit_hint(key)
+                        ),
+                        severity=DiagnosticSeverity.Error,
+                        source=_DIAGNOSTIC_SOURCE,
+                        code="TYPE_INTEGER",
+                    )
+                )
+                return
+            int_val = int(value)
+            if int_val <= 0:
+                diagnostics.append(
+                    Diagnostic(
+                        range=Range(
+                            start=Position(line=line, character=col_start),
+                            end=Position(line=line, character=col_end),
+                        ),
+                        message=(
+                            f"Expected positive integer for {kw_upper} in "
+                            f"${group_name}, got {int_val}."
+                            + self._unit_hint(key)
+                        ),
+                        severity=DiagnosticSeverity.Error,
+                        source=_DIAGNOSTIC_SOURCE,
+                        code="TYPE_POSITIVE_INTEGER",
+                    )
+                )
+            return
+
+        # General integer check
+        if key in _INTEGER_KEYWORDS:
+            if not _INTEGER_RE.match(value):
+                diagnostics.append(
+                    Diagnostic(
+                        range=Range(
+                            start=Position(line=line, character=col_start),
+                            end=Position(line=line, character=col_end),
+                        ),
+                        message=(
+                            f"Expected integer for {kw_upper} in ${group_name}, "
+                            f"got '{value}'."
+                            + self._unit_hint(key)
+                        ),
+                        severity=DiagnosticSeverity.Error,
+                        source=_DIAGNOSTIC_SOURCE,
+                        code="TYPE_INTEGER",
+                    )
+                )
+            return
+
+        # Float check
+        if key in _FLOAT_KEYWORDS:
+            if not _NUMERIC_RE.match(value):
+                diagnostics.append(
+                    Diagnostic(
+                        range=Range(
+                            start=Position(line=line, character=col_start),
+                            end=Position(line=line, character=col_end),
+                        ),
+                        message=(
+                            f"Expected numeric value for {kw_upper} in "
+                            f"${group_name}, got '{value}'."
+                            + self._unit_hint(key)
+                        ),
+                        severity=DiagnosticSeverity.Error,
+                        source=_DIAGNOSTIC_SOURCE,
+                        code="TYPE_NUMERIC",
+                    )
+                )
+            return
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _value_column(keyword: GAMESSKeyword) -> int:
+        """Estimate the column where the value starts on the keyword's line.
+
+        GAMESS keyword lines look like ``KEY=VALUE`` or `` KEY=VALUE``.
+        We look for the ``=`` and advance past it.
+        """
+        return len(keyword.name) + 1  # len(key) + "="
+
+    @staticmethod
+    def _unit_hint(key: tuple[str, str]) -> str:
+        """Return a unit annotation string if one is defined for *key*."""
+        unit = _UNIT_ANNOTATIONS.get(key)
+        if unit:
+            return f" Unit: {unit}."
+        return ""
+
+
+__all__ = ["TypecheckProvider"]

--- a/src/gamess_lsp/server.py
+++ b/src/gamess_lsp/server.py
@@ -43,6 +43,7 @@ from pygls.server import LanguageServer
 from pygls.workspace import Document
 
 from .features.diagnostic import DiagnosticProvider
+from .features.typecheck import TypecheckProvider
 from .features.lint import LintProvider
 from .keywords import GAMESS_GROUPS, GAMESS_KEYWORDS
 from .parser import GAMESSParser
@@ -374,6 +375,10 @@ def _get_diagnostics(content: str) -> List[Diagnostic]:
             )
         )
 
+
+    # 3. Typecheck diagnostics (enum, type, required sections)
+    typecheck_provider = TypecheckProvider()
+    diagnostics.extend(typecheck_provider.validate(parsed_input))
     return diagnostics
 
 

--- a/tests/features/test_diagnostic.py
+++ b/tests/features/test_diagnostic.py
@@ -46,15 +46,18 @@ class TestEmptyInput:
     def test_empty_string_no_diagnostics(self, provider: DiagnosticProvider) -> None:
         diagnostics = provider.get_diagnostics("")
         assert isinstance(diagnostics, list)
-        assert len(diagnostics) == 0
+        # Empty input triggers missing required group diagnostics from typecheck
+        assert all(d.source == "gamess-lsp-typecheck" for d in diagnostics)
 
     def test_whitespace_only_no_diagnostics(self, provider: DiagnosticProvider) -> None:
         diagnostics = provider.get_diagnostics("   \n  \n")
-        assert len(diagnostics) == 0
+        # Whitespace input triggers missing required group diagnostics from typecheck
+        assert all(d.source == "gamess-lsp-typecheck" for d in diagnostics)
 
     def test_comment_only_no_diagnostics(self, provider: DiagnosticProvider) -> None:
         diagnostics = provider.get_diagnostics("! This is a comment\n")
-        assert len(diagnostics) == 0
+        # Comment-only input triggers missing required group diagnostics from typecheck
+        assert all(d.source == "gamess-lsp-typecheck" for d in diagnostics)
 
 
 # ------------------------------------------------------------------
@@ -69,7 +72,8 @@ class TestValidInput:
         text = "$CONTRL\n SCFTYP=RHF RUNTYP=ENERGY\n $END"
         diagnostics = provider.get_diagnostics(text)
         assert isinstance(diagnostics, list)
-        assert len(diagnostics) == 0
+        # Missing $DATA triggers typecheck diagnostic; no syntax/semantic errors
+        assert all(d.source == "gamess-lsp-typecheck" for d in diagnostics)
 
     def test_valid_multi_group(self, provider: DiagnosticProvider) -> None:
         text = (
@@ -79,7 +83,8 @@ class TestValidInput:
         )
         diagnostics = provider.get_diagnostics(text)
         assert isinstance(diagnostics, list)
-        assert len(diagnostics) == 0
+        # Missing $DATA triggers typecheck diagnostic; no syntax/semantic errors
+        assert all(d.source == "gamess-lsp-typecheck" for d in diagnostics)
 
     def test_valid_full_calculation(self, provider: DiagnosticProvider) -> None:
         text = (
@@ -184,7 +189,9 @@ class TestSnapshot:
 
     def test_snapshot_empty_diagnostics(self, provider: DiagnosticProvider) -> None:
         snap = provider.snapshot("file:///test.inp", "")
-        assert snap["diagnostics"] == []
+        # Empty input triggers missing required group diagnostics
+        assert len(snap["diagnostics"]) >= 1
+        assert all(d["source"] == "gamess-lsp-typecheck" for d in snap["diagnostics"])
 
     def test_snapshot_with_diagnostics(self, provider: DiagnosticProvider) -> None:
         snap = provider.snapshot("file:///test.inp", "$UNKNOWN $END")
@@ -232,7 +239,7 @@ class TestSnapshot:
     def test_snapshot_source_is_gamess_lsp(self, provider: DiagnosticProvider) -> None:
         snap = provider.snapshot("file:///test.inp", "$CONTRL SCFTYP=INVALID $END")
         sources = {d["source"] for d in snap["diagnostics"]}
-        assert sources == {"gamess-lsp"}
+        assert "gamess-lsp" in sources
 
     def test_snapshot_range_structure(self, provider: DiagnosticProvider) -> None:
         snap = provider.snapshot("file:///test.inp", "$UNKNOWN $END")

--- a/tests/features/test_typecheck.py
+++ b/tests/features/test_typecheck.py
@@ -1,0 +1,658 @@
+"""Tests for the TypecheckProvider feature.
+
+Covers:
+- Required group validation ($CONTRL, $DATA)
+- Enum value validation (SCFTYP, RUNTYP, GBASIS, etc.)
+- Boolean type checking
+- Integer type checking (positive and general)
+- Float / numeric type checking
+- Unit annotations in diagnostics
+- Valid inputs that should produce no typecheck diagnostics
+"""
+
+import pytest
+
+from gamess_lsp.features.typecheck import TypecheckProvider
+from gamess_lsp.parser import GAMESSParser
+
+# Shorter alias for severity constant
+from lsprotocol.types import DiagnosticSeverity
+
+_ERROR = DiagnosticSeverity.Error
+_WARNING = DiagnosticSeverity.Warning
+
+
+@pytest.fixture
+def provider() -> TypecheckProvider:
+    """Create a TypecheckProvider instance."""
+    return TypecheckProvider()
+
+
+def _parse_and_validate(text: str) -> list:
+    """Parse text, run typecheck validation, and return diagnostics."""
+    parser = GAMESSParser()
+    parsed = parser.parse(text)
+    provider = TypecheckProvider()
+    return provider.validate(parsed)
+
+
+def _messages(diagnostics: list) -> list[str]:
+    """Extract messages from a diagnostic list."""
+    return [d.message for d in diagnostics]
+
+
+def _codes(diagnostics: list) -> list[str]:
+    """Extract codes from a diagnostic list."""
+    return [str(d.code) for d in diagnostics if d.code]
+
+
+def _sources(diagnostics: list) -> set[str]:
+    """Extract unique sources from a diagnostic list."""
+    return {d.source for d in diagnostics if d.source}
+
+
+# ------------------------------------------------------------------
+# Provider instantiation
+# ------------------------------------------------------------------
+
+
+class TestProviderExists:
+    """Sanity checks that the provider can be created."""
+
+    def test_provider_not_none(self, provider: TypecheckProvider) -> None:
+        assert provider is not None
+
+
+# ------------------------------------------------------------------
+# Required groups
+# ------------------------------------------------------------------
+
+
+class TestRequiredGroups:
+    """Validate missing required group detection."""
+
+    def test_missing_contrl_group(self) -> None:
+        """$CONTRL is always required."""
+        text = "$SYSTEM MWORDS=100 $END"
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("$CONTRL group is required" in m for m in msgs)
+
+    def test_missing_data_group(self) -> None:
+        """$DATA is always required."""
+        text = "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END"
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("$DATA group is required" in m for m in msgs)
+
+    def test_both_groups_present_no_missing_error(self) -> None:
+        """No missing-group errors when both $CONTRL and $DATA are present."""
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$DATA\nTitle\nC1\n\nO 8.0 0.0 0.0 0.0\n $END\n"
+        )
+        diagnostics = _parse_and_validate(text)
+        missing_codes = [c for c in _codes(diagnostics) if c == "MISSING_REQUIRED_GROUP"]
+        assert len(missing_codes) == 0
+
+    def test_missing_group_code(self) -> None:
+        """Diagnostics have code MISSING_REQUIRED_GROUP."""
+        text = "$SYSTEM MWORDS=100 $END"
+        diagnostics = _parse_and_validate(text)
+        assert "MISSING_REQUIRED_GROUP" in _codes(diagnostics)
+
+    def test_missing_group_source(self) -> None:
+        """Missing-group diagnostics use the typecheck source."""
+        text = "$SYSTEM MWORDS=100 $END"
+        diagnostics = _parse_and_validate(text)
+        assert "gamess-lsp-typecheck" in _sources(diagnostics)
+
+
+# ------------------------------------------------------------------
+# Enum validation
+# ------------------------------------------------------------------
+
+
+class TestEnumValidation:
+    """Validate enum value checking."""
+
+    def test_invalid_scftyp(self) -> None:
+        text = "$CONTRL SCFTYP=BADVALUE RUNTYP=ENERGY $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("Invalid value" in m and "SCFTYP" in m for m in msgs)
+
+    def test_valid_scftyp_no_error(self) -> None:
+        text = "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        enum_errors = [c for c in _codes(diagnostics) if c == "INVALID_ENUM"]
+        assert len(enum_errors) == 0
+
+    def test_invalid_runtyp(self) -> None:
+        text = "$CONTRL SCFTYP=RHF RUNTYP=BOGUS $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("Invalid value" in m and "RUNTYP" in m for m in msgs)
+
+    def test_invalid_gbasis(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$BASIS GBASIS=FAKE $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("Invalid value" in m and "GBASIS" in m for m in msgs)
+
+    def test_invalid_scftyp_lists_allowed_values(self) -> None:
+        """Error message should list allowed values."""
+        text = "$CONTRL SCFTYP=BADVALUE $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        enum_msgs = [m for m in msgs if "SCFTYP" in m and "Invalid value" in m]
+        assert len(enum_msgs) >= 1
+        assert "RHF" in enum_msgs[0]
+        assert "UHF" in enum_msgs[0]
+
+    def test_enum_case_insensitive(self) -> None:
+        """Enum matching should be case-insensitive (valid lowercase)."""
+        text = "$CONTRL SCFTYP=rhf RUNTYP=energy $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        enum_errors = [c for c in _codes(diagnostics) if c == "INVALID_ENUM"]
+        assert len(enum_errors) == 0
+
+    def test_enum_diagnostic_code(self) -> None:
+        text = "$CONTRL SCFTYP=BAD $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        assert "INVALID_ENUM" in _codes(diagnostics)
+
+    def test_enum_diagnostic_source(self) -> None:
+        text = "$CONTRL SCFTYP=BAD $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        assert "gamess-lsp-typecheck" in _sources(diagnostics)
+
+    def test_enum_diagnostic_range_points_to_value(self) -> None:
+        """The diagnostic range should target the value, not the whole line."""
+        text = "$CONTRL SCFTYP=BAD $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        enum_diags = [d for d in diagnostics if d.code == "INVALID_ENUM"]
+        assert len(enum_diags) >= 1
+        diag = enum_diags[0]
+        # Value column should be after "SCFTYP="
+        assert diag.range.start.character >= 6  # len("SCFTYP") + 1
+
+    def test_statpt_method_enum(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=OPTIMIZE $END\n"
+            "$STATPT METHOD=INVALID $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("Invalid value" in m and "METHOD" in m for m in msgs)
+
+    def test_pcm_solvnt_enum(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$PCM SOLVNT=INVALID $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("Invalid value" in m and "SOLVNT" in m for m in msgs)
+
+
+# ------------------------------------------------------------------
+# Boolean type validation
+# ------------------------------------------------------------------
+
+
+class TestBooleanType:
+    """Validate boolean keyword type checking."""
+
+    def test_invalid_boolean_value(self) -> None:
+        text = "$CONTRL SCFTYP=RHF RUNTYP=ENERGY NOSYM=YES $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("Expected boolean" in m and "NOSYM" in m for m in msgs)
+
+    def test_valid_boolean_true(self) -> None:
+        text = "$CONTRL SCFTYP=RHF RUNTYP=ENERGY NOSYM=.TRUE. $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        bool_errors = [m for m in _messages(diagnostics) if "NOSYM" in m and "boolean" in m.lower()]
+        assert len(bool_errors) == 0
+
+    def test_valid_boolean_false(self) -> None:
+        text = "$CONTRL SCFTYP=RHF RUNTYP=ENERGY NOSYM=.FALSE. $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        bool_errors = [m for m in _messages(diagnostics) if "NOSYM" in m and "boolean" in m.lower()]
+        assert len(bool_errors) == 0
+
+    def test_valid_boolean_one(self) -> None:
+        text = "$CONTRL SCFTYP=RHF RUNTYP=ENERGY NOSYM=1 $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        bool_errors = [m for m in _messages(diagnostics) if "NOSYM" in m and "boolean" in m.lower()]
+        assert len(bool_errors) == 0
+
+    def test_valid_boolean_zero(self) -> None:
+        text = "$CONTRL SCFTYP=RHF RUNTYP=ENERGY NOSYM=0 $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        bool_errors = [m for m in _messages(diagnostics) if "NOSYM" in m and "boolean" in m.lower()]
+        assert len(bool_errors) == 0
+
+    def test_boolean_diagnostic_code(self) -> None:
+        text = "$CONTRL SCFTYP=RHF RUNTYP=ENERGY NOSYM=YES $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        assert "TYPE_BOOLEAN" in _codes(diagnostics)
+
+    def test_scf_dirscf_boolean(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$SCF DIRSCF=MAYBE $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("Expected boolean" in m and "DIRSCF" in m for m in msgs)
+
+    def test_basis_diffsp_boolean(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$BASIS GBASIS=STO NGAUSS=3 DIFFSP=ON $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("Expected boolean" in m and "DIFFSP" in m for m in msgs)
+
+
+# ------------------------------------------------------------------
+# Integer type validation
+# ------------------------------------------------------------------
+
+
+class TestIntegerType:
+    """Validate integer keyword type checking."""
+
+    def test_non_integer_mwords(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$SYSTEM MWORDS=abc $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("Expected positive integer" in m and "MWORDS" in m for m in msgs)
+
+    def test_float_mwords(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$SYSTEM MWORDS=1.5 $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("Expected positive integer" in m and "MWORDS" in m for m in msgs)
+
+    def test_valid_integer_mwords(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$SYSTEM MWORDS=100 $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        int_errors = [m for m in _messages(diagnostics) if "MWORDS" in m and "integer" in m.lower()]
+        assert len(int_errors) == 0
+
+    def test_zero_mwords(self) -> None:
+        """MWORDS must be positive; zero should be flagged."""
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$SYSTEM MWORDS=0 $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("positive integer" in m and "MWORDS" in m for m in msgs)
+
+    def test_negative_mwords(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$SYSTEM MWORDS=-5 $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("positive integer" in m and "MWORDS" in m for m in msgs)
+
+    def test_integer_diagnostic_code(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$SYSTEM MWORDS=abc $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        assert "TYPE_INTEGER" in _codes(diagnostics)
+
+    def test_negative_icharg_allowed(self) -> None:
+        """ICHARG can be negative (anion). It is a general integer, not positive-only."""
+        text = "$CONTRL SCFTYP=RHF RUNTYP=ENERGY ICHARG=-1 $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        int_errors = [m for m in _messages(diagnostics) if "ICHARG" in m and "integer" in m.lower()]
+        assert len(int_errors) == 0
+
+    def test_statpt_nstep_non_integer(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=OPTIMIZE $END\n"
+            "$STATPT NSTEP=many $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("Expected positive integer" in m and "NSTEP" in m for m in msgs)
+
+    def test_ispher_negative_one_allowed(self) -> None:
+        """ISPHER accepts -1 (general integer, not positive-only)."""
+        text = "$CONTRL SCFTYP=RHF RUNTYP=ENERGY ISPHER=-1 $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        int_errors = [m for m in _messages(diagnostics) if "ISPHER" in m and "integer" in m.lower()]
+        assert len(int_errors) == 0
+
+
+# ------------------------------------------------------------------
+# Float / numeric type validation
+# ------------------------------------------------------------------
+
+
+class TestFloatType:
+    """Validate float keyword type checking."""
+
+    def test_non_numeric_opttol(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=OPTIMIZE $END\n"
+            "$STATPT OPTTOL=small $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("Expected numeric" in m and "OPTTOL" in m for m in msgs)
+
+    def test_valid_float_opttol(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=OPTIMIZE $END\n"
+            "$STATPT OPTTOL=0.0001 $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        float_errors = [m for m in _messages(diagnostics) if "OPTTOL" in m and "numeric" in m.lower()]
+        assert len(float_errors) == 0
+
+    def test_scientific_notation_opttol(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=OPTIMIZE $END\n"
+            "$STATPT OPTTOL=1.0E-4 $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        float_errors = [m for m in _messages(diagnostics) if "OPTTOL" in m and "numeric" in m.lower()]
+        assert len(float_errors) == 0
+
+    def test_scientific_notation_lowercase(self) -> None:
+        """GAMESS accepts lowercase 'e' and 'd' in scientific notation."""
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=OPTIMIZE $END\n"
+            "$STATPT OPTTOL=1.0e-4 $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        float_errors = [m for m in _messages(diagnostics) if "OPTTOL" in m and "numeric" in m.lower()]
+        assert len(float_errors) == 0
+
+    def test_d_notation(self) -> None:
+        """GAMESS Fortran-style 'D' exponent notation."""
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=OPTIMIZE $END\n"
+            "$STATPT OPTTOL=1.0D-4 $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        float_errors = [m for m in _messages(diagnostics) if "OPTTOL" in m and "numeric" in m.lower()]
+        assert len(float_errors) == 0
+
+    def test_numeric_diagnostic_code(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=OPTIMIZE $END\n"
+            "$STATPT OPTTOL=bad $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        assert "TYPE_NUMERIC" in _codes(diagnostics)
+
+    def test_force_temp_non_numeric(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=HESSIAN $END\n"
+            "$FORCE TEMP=room $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("Expected numeric" in m and "TEMP" in m for m in msgs)
+
+    def test_ccconv_float(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY CCTYP=CCSD $END\n"
+            "$CC CCCONV=1.0E-06 $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        float_errors = [m for m in _messages(diagnostics) if "CCCONV" in m and "numeric" in m.lower()]
+        assert len(float_errors) == 0
+
+
+# ------------------------------------------------------------------
+# Unit annotations
+# ------------------------------------------------------------------
+
+
+class TestUnitAnnotations:
+    """Validate that unit hints appear in diagnostic messages."""
+
+    def test_mwords_unit_in_error(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$SYSTEM MWORDS=bad $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        mwords_msgs = [m for m in msgs if "MWORDS" in m]
+        assert len(mwords_msgs) >= 1
+        assert "million words" in mwords_msgs[0]
+
+    def test_temp_unit_in_error(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=HESSIAN $END\n"
+            "$FORCE TEMP=bad $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        temp_msgs = [m for m in msgs if "TEMP" in m]
+        assert len(temp_msgs) >= 1
+        assert "Kelvin" in temp_msgs[0]
+
+    def test_timlim_unit_in_error(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$SYSTEM TIMLIM=forever $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        timlim_msgs = [m for m in msgs if "TIMLIM" in m]
+        assert len(timlim_msgs) >= 1
+        assert "minutes" in timlim_msgs[0]
+
+
+# ------------------------------------------------------------------
+# Valid inputs (no typecheck errors)
+# ------------------------------------------------------------------
+
+
+class TestValidInput:
+    """Valid inputs should produce no typecheck diagnostics."""
+
+    def test_minimal_valid(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY $END\n"
+            "$DATA\nTitle\nC1\n\nO 8.0 0.0 0.0 0.0\n $END\n"
+        )
+        diagnostics = _parse_and_validate(text)
+        assert len(diagnostics) == 0
+
+    def test_full_valid_calculation(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF DFTTYP=B3LYP RUNTYP=OPTIMIZE $END\n"
+            "$SYSTEM MWORDS=100 $END\n"
+            "$BASIS GBASIS=CC-PVDZ $END\n"
+            "$STATPT OPTTOL=0.0001 NSTEP=50 $END\n"
+            "$DATA\nWater\nC1\n\n"
+            "O 8.0 0.0 0.0 0.117\n"
+            "H 1.0 0.0 0.757 -0.470\n"
+            "H 1.0 0.0 -0.757 -0.470\n"
+            " $END\n"
+        )
+        diagnostics = _parse_and_validate(text)
+        assert len(diagnostics) == 0
+
+    def test_valid_mp2(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY MPLEVL=2 $END\n"
+            "$SYSTEM MWORDS=100 $END\n"
+            "$BASIS GBASIS=CC-PVDZ $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END\n"
+        )
+        diagnostics = _parse_and_validate(text)
+        assert len(diagnostics) == 0
+
+    def test_valid_ccsd(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY CCTYP=CCSD(T) $END\n"
+            "$SYSTEM MWORDS=100 MEMDDI=1000 $END\n"
+            "$BASIS GBASIS=CC-PVTZ $END\n"
+            "$CC NCORE=0 MAXCC=100 CCCONV=1.0E-06 $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END\n"
+        )
+        diagnostics = _parse_and_validate(text)
+        assert len(diagnostics) == 0
+
+    def test_valid_pcm(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF DFTTYP=B3LYP RUNTYP=OPTIMIZE $END\n"
+            "$PCM SOLVNT=WATER RSOLV=1.0 $END\n"
+            "$BASIS GBASIS=CC-PVDZ $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END\n"
+        )
+        diagnostics = _parse_and_validate(text)
+        assert len(diagnostics) == 0
+
+    def test_valid_tddft(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF DFTTYP=B3LYP RUNTYP=ENERGY $END\n"
+            "$TDDFT NSTATE=5 IROOT=1 CVG=1.0E-05 $END\n"
+            "$BASIS GBASIS=CC-PVDZ $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END\n"
+        )
+        diagnostics = _parse_and_validate(text)
+        assert len(diagnostics) == 0
+
+
+# ------------------------------------------------------------------
+# Multiple errors
+# ------------------------------------------------------------------
+
+
+class TestMultipleErrors:
+    """Verify that multiple errors are reported correctly."""
+
+    def test_multiple_type_errors(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=RHF RUNTYP=ENERGY NOSYM=YES MAXIT=five $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        msgs = _messages(diagnostics)
+        assert any("boolean" in m.lower() and "NOSYM" in m for m in msgs)
+        assert any("integer" in m.lower() and "MAXIT" in m for m in msgs)
+
+    def test_enum_and_type_errors(self) -> None:
+        text = (
+            "$CONTRL SCFTYP=BAD RUNTYP=WORSE NOSYM=YES $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = _parse_and_validate(text)
+        codes = _codes(diagnostics)
+        assert "INVALID_ENUM" in codes
+        assert "TYPE_BOOLEAN" in codes
+
+
+# ------------------------------------------------------------------
+# Diagnostic source
+# ------------------------------------------------------------------
+
+
+class TestDiagnosticSource:
+    """All typecheck diagnostics should carry the correct source."""
+
+    def test_all_diagnostics_use_typecheck_source(self) -> None:
+        text = "$CONTRL SCFTYP=RHF RUNTYP=ENERGY NOSYM=YES MAXIT=bad $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        assert len(diagnostics) > 0
+        for d in diagnostics:
+            assert d.source == "gamess-lsp-typecheck"
+
+    def test_severity_is_error(self) -> None:
+        text = "$CONTRL SCFTYP=BAD $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = _parse_and_validate(text)
+        for d in diagnostics:
+            assert d.severity == DiagnosticSeverity.Error
+
+
+# ------------------------------------------------------------------
+# Integration with DiagnosticProvider
+# ------------------------------------------------------------------
+
+
+class TestDiagnosticProviderIntegration:
+    """Verify typecheck diagnostics flow through the DiagnosticProvider."""
+
+    def test_typecheck_errors_in_provider(self) -> None:
+        from pygls.server import LanguageServer
+        from gamess_lsp.features.diagnostic import DiagnosticProvider
+
+        server = LanguageServer("test", "1.0")
+        provider = DiagnosticProvider(server)
+
+        text = "$CONTRL SCFTYP=RHF RUNTYP=ENERGY NOSYM=YES $END\n$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        diagnostics = provider.get_diagnostics(text)
+        sources = {d.source for d in diagnostics if d.source}
+        assert "gamess-lsp-typecheck" in sources
+
+    def test_typecheck_and_semantic_errors_coexist(self) -> None:
+        from pygls.server import LanguageServer
+        from gamess_lsp.features.diagnostic import DiagnosticProvider
+
+        server = LanguageServer("test", "1.0")
+        provider = DiagnosticProvider(server)
+
+        # DFT+MP2 (semantic error) + invalid boolean (typecheck error)
+        text = (
+            "$CONTRL SCFTYP=RHF DFTTYP=B3LYP MPLEVL=2 NOSYM=YES $END\n"
+            "$DATA\nT\nC1\n\nO 8 0 0 0\n $END"
+        )
+        diagnostics = provider.get_diagnostics(text)
+        sources = {d.source for d in diagnostics if d.source}
+        msgs = [d.message for d in diagnostics]
+        assert "gamess-lsp-typecheck" in sources
+        assert "gamess-lsp" in sources
+        assert any("boolean" in m.lower() and "NOSYM" in m for m in msgs)

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -32,7 +32,8 @@ class TestGetDiagnostics:
         """Test diagnostics for empty content."""
         diagnostics = _get_diagnostics("")
         assert isinstance(diagnostics, list)
-        assert len(diagnostics) == 0
+        # Empty input triggers missing required group diagnostics from typecheck
+        assert all(d.source == "gamess-lsp-typecheck" for d in diagnostics)
 
     def test_get_diagnostics_warning(self):
         """Test diagnostics with warning."""


### PR DESCRIPTION
## Summary

Implements `TypecheckProvider` for validating GAMESS keyword value types, enums, units, and required sections (closes #42).

### What it does

- **Enum validation**: Checks values against restricted sets for SCFTYP, RUNTYP, GBASIS, METHOD, SOLVNT, etc.
- **Boolean type checking**: Validates .TRUE./.FALSE./1/0 for boolean keywords (NOSYM, DIRSCF, DIIS, etc.)
- **Integer type checking**: Positive-integer and general-integer validation with range checks (MWORDS, NSTEP, MAXIT, ICHARG, etc.)
- **Float/numeric type checking**: Validates numeric values including Fortran D-notation (OPTTOL, CONV, TEMP, etc.)
- **Unit annotations**: Diagnostic messages include unit context (Kelvin, Hartree, minutes, Angstroms, etc.)
- **Required sections**: Reports missing $CONTRL and $DATA groups

### Implementation

- New file: `src/gamess_lsp/features/typecheck.py` with `TypecheckProvider` class
- Wired into `DiagnosticProvider` and `server._get_diagnostics()`
- Diagnostics carry `source="gamess-lsp-typecheck"` for independent filtering
- Updated 8 existing tests to account for new typecheck diagnostics

### Tests

- 57 new tests in `tests/features/test_typecheck.py` covering:
  - Required group validation
  - Enum value validation (valid/invalid/case-insensitive)
  - Boolean type checks
  - Integer type checks (positive, general, negative allowed)
  - Float/numeric type checks (including scientific and D-notation)
  - Unit annotations in error messages
  - Valid inputs producing no typecheck diagnostics
  - Multiple simultaneous errors
  - Integration with DiagnosticProvider

All 369 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)