### PR TITLE
feat(format): GAMESS document and range formatting

### DIFF
--- a/src/gamess_lsp/features/formatting.py
+++ b/src/gamess_lsp/features/formatting.py
@@ -1,0 +1,415 @@
+"""LSP formatting provider for GAMESS input files.
+
+This module provides document and range formatting for GAMESS input files,
+including group indentation, keyword normalization (uppercase), comment
+preservation, and $DATA section handling.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import List
+
+from lsprotocol.types import (
+    DocumentFormattingParams,
+    DocumentRangeFormattingParams,
+    FormattingOptions,
+    Position,
+    Range,
+    TextEdit,
+)
+from pygls.server import LanguageServer
+
+from ..tokenizer import tokenize_line
+
+
+class GamessFormattingProvider:
+    """Provides formatting for GAMESS input files.
+
+    Handles:
+    - Consistent indentation of group bodies
+    - Keyword normalization (uppercase group names and keywords)
+    - Preservation of comments and blank lines
+    - $DATA section content preserved without keyword formatting
+    - Range formatting for partial document edits
+    """
+
+    def __init__(self, server: LanguageServer) -> None:
+        """Initialize the formatting provider.
+
+        Args:
+            server: The language server instance.
+        """
+        self.server = server
+
+    def format_document(
+        self, text: str, params: DocumentFormattingParams
+    ) -> List[TextEdit]:
+        """Format the entire document.
+
+        Args:
+            text: Document text.
+            params: Formatting parameters.
+
+        Returns:
+            List of text edits to apply.
+        """
+        options = params.options or FormattingOptions(tab_size=2, insert_spaces=True)
+        formatted = self._format_text(text, options)
+
+        if formatted == text:
+            return []
+
+        lines = text.splitlines()
+        return [
+            TextEdit(
+                range=Range(
+                    start=Position(line=0, character=0),
+                    end=Position(line=len(lines), character=0),
+                ),
+                new_text=formatted,
+            )
+        ]
+
+    def format_range(
+        self, text: str, params: DocumentRangeFormattingParams
+    ) -> List[TextEdit]:
+        """Format a specific range of the document.
+
+        For range formatting, the provider formats only the selected line range.
+        It determines the correct indentation context by scanning from the
+        document start so that group nesting is respected.
+
+        Args:
+            text: Document text.
+            params: Range formatting parameters.
+
+        Returns:
+            List of text edits to apply.
+        """
+        options = params.options or FormattingOptions(tab_size=2, insert_spaces=True)
+        all_lines = text.splitlines()
+
+        start_line = params.range.start.line
+        end_line = params.range.end.line
+
+        # Clamp to valid range
+        start_line = max(0, start_line)
+        end_line = min(len(all_lines) - 1, end_line)
+
+        if start_line > end_line:
+            return []
+
+        indent_str = " " * options.tab_size if options.insert_spaces else "\t"
+
+        # Compute indent context from the beginning of the document
+        # so we know the correct nesting level at the range start.
+        indent_level, in_data = self._compute_context_at_line(
+            all_lines, start_line
+        )
+
+        edits: List[TextEdit] = []
+
+        for i in range(start_line, end_line + 1):
+            if i >= len(all_lines):
+                break
+
+            original = all_lines[i]
+            formatted = self._format_line(original, indent_level, in_data, indent_str)
+
+            if formatted != original:
+                line_length = len(original)
+                edits.append(
+                    TextEdit(
+                        range=Range(
+                            start=Position(line=i, character=0),
+                            end=Position(line=i, character=line_length),
+                        ),
+                        new_text=formatted,
+                    )
+                )
+
+            # Update context for next line based on this line
+            indent_level, in_data = self._update_context(
+                formatted.strip(), indent_level, in_data
+            )
+
+        return edits
+
+    def _format_text(self, text: str, options: FormattingOptions) -> str:
+        """Format the full text and return the formatted version.
+
+        Args:
+            text: Full document text.
+            options: Formatting options.
+
+        Returns:
+            Formatted text.
+        """
+        lines = text.splitlines()
+        indent_str = " " * options.tab_size if options.insert_spaces else "\t"
+        indent_level = 0
+        in_data = False
+        data_line_count = 0
+        formatted_lines: List[str] = []
+
+        for line in lines:
+            stripped = line.strip()
+
+            # Empty lines: preserve as blank
+            if not stripped:
+                formatted_lines.append("")
+                continue
+
+            # Comments: preserve content, strip leading whitespace
+            if stripped.startswith("!"):
+                formatted_lines.append(stripped)
+                continue
+
+            # $END: decrease indent, exit group
+            if re.match(r"^\$END\b", stripped, re.IGNORECASE):
+                indent_level = max(0, indent_level - 1)
+                in_data = False
+                data_line_count = 0
+                formatted_lines.append(
+                    indent_str * indent_level + "$END"
+                )
+                continue
+
+            # Group start: $GROUPNAME
+            group_match = re.match(r"^\$([A-Za-z_][A-Za-z0-9_]*)\s*(.*)", stripped)
+            if group_match:
+                group_name = group_match.group(1).upper()
+                rest = group_match.group(2).strip()
+
+                formatted_lines.append(indent_str * indent_level + f"${group_name}")
+                indent_level += 1
+
+                if group_name == "DATA":
+                    in_data = True
+                    data_line_count = 0
+
+                if rest:
+                    # Handle inline content after group name
+                    if rest.upper().startswith("$END"):
+                        indent_level = max(0, indent_level - 1)
+                        in_data = False
+                        formatted_lines.append(
+                            indent_str * indent_level + "$END"
+                        )
+                    elif in_data:
+                        # Inside $DATA: title/symmetry line
+                        data_line_count += 1
+                        formatted_lines.append(indent_str * indent_level + rest)
+                    else:
+                        # Inline keywords after group name
+                        formatted_keywords = self._format_keywords(rest)
+                        formatted_lines.append(
+                            indent_str * indent_level + formatted_keywords
+                        )
+
+                continue
+
+            # Inside $DATA group: preserve geometry lines
+            if in_data:
+                data_line_count += 1
+                formatted_lines.append(indent_str * indent_level + stripped)
+                continue
+
+            # Regular keyword line inside a group
+            if indent_level > 0 and "=" in stripped:
+                formatted_keywords = self._format_keywords(stripped)
+                formatted_lines.append(
+                    indent_str * indent_level + formatted_keywords
+                )
+                continue
+
+            # Fallback: preserve stripped content at current indent
+            formatted_lines.append(indent_str * indent_level + stripped)
+
+        result = "\n".join(formatted_lines)
+        if text.endswith("\n"):
+            result += "\n"
+
+        return result
+
+    def _format_line(
+        self,
+        original_line: str,
+        indent_level: int,
+        in_data: bool,
+        indent_str: str,
+    ) -> str:
+        """Format a single line with the given context.
+
+        Args:
+            original_line: The raw line content.
+            indent_level: Current indentation level.
+            in_data: Whether we are inside a $DATA group.
+            indent_str: Indentation string (spaces or tab).
+
+        Returns:
+            Formatted line.
+        """
+        stripped = original_line.strip()
+
+        if not stripped:
+            return ""
+
+        if stripped.startswith("!"):
+            return stripped
+
+        # $END
+        if re.match(r"^\$END\b", stripped, re.IGNORECASE):
+            level = max(0, indent_level - 1)
+            return indent_str * level + "$END"
+
+        # Group start
+        group_match = re.match(r"^\$([A-Za-z_][A-Za-z0-9_]*)\s*(.*)", stripped)
+        if group_match:
+            group_name = group_match.group(1).upper()
+            rest = group_match.group(2).strip()
+            result = indent_str * indent_level + f"${group_name}"
+            if rest:
+                if "=" in rest:
+                    result += "\n" + indent_str * (indent_level + 1) + self._format_keywords(rest)
+                else:
+                    result += " " + rest
+            return result
+
+        # Inside $DATA: preserve as-is with indent
+        if in_data:
+            return indent_str * indent_level + stripped
+
+        # Regular keyword line inside a group
+        if indent_level > 0 and "=" in stripped:
+            return indent_str * indent_level + self._format_keywords(stripped)
+
+        return indent_str * indent_level + stripped
+
+    @staticmethod
+    def _compute_context_at_line(
+        lines: List[str], target_line: int
+    ) -> tuple[int, bool]:
+        """Compute the indentation level and $DATA context at a target line.
+
+        Args:
+            lines: All lines in the document.
+            target_line: The line index to compute context for.
+
+        Returns:
+            Tuple of (indent_level, in_data) at the start of target_line.
+        """
+        indent_level = 0
+        in_data = False
+
+        for i in range(target_line):
+            if i >= len(lines):
+                break
+
+            stripped = lines[i].strip()
+            if not stripped or stripped.startswith("!"):
+                continue
+
+            if re.match(r"^\$END\b", stripped, re.IGNORECASE):
+                indent_level = max(0, indent_level - 1)
+                in_data = False
+            else:
+                group_match = re.match(
+                    r"^\$([A-Za-z_][A-Za-z0-9_]*)", stripped
+                )
+                if group_match:
+                    group_name = group_match.group(1).upper()
+                    if group_name != "END":
+                        indent_level += 1
+                        in_data = group_name == "DATA"
+
+        return indent_level, in_data
+
+    @staticmethod
+    def _update_context(
+        stripped_line: str,
+        current_level: int,
+        in_data: bool,
+    ) -> tuple[int, bool]:
+        """Update context after processing a line.
+
+        Args:
+            stripped_line: Stripped line content.
+            current_level: Current indent level.
+            in_data: Whether currently inside $DATA.
+
+        Returns:
+            Tuple of (updated_level, updated_in_data).
+        """
+        if not stripped_line or stripped_line.startswith("!"):
+            return current_level, in_data
+
+        if re.match(r"^\$END\b", stripped_line, re.IGNORECASE):
+            return max(0, current_level - 1), False
+
+        group_match = re.match(r"^\$([A-Za-z_][A-Za-z0-9_]*)", stripped_line)
+        if group_match:
+            group_name = group_match.group(1).upper()
+            if group_name != "END":
+                return current_level + 1, group_name == "DATA"
+
+        return current_level, in_data
+
+    @staticmethod
+    def _format_keywords(line: str) -> str:
+        """Format a line of keyword=value pairs.
+
+        Tokenizes the line, normalizes spacing around equals signs,
+        and uppercases keyword names.  Handles cases where ``=`` is a
+        standalone token (``KEY = VALUE``) by merging with adjacent tokens.
+
+        Args:
+            line: Line containing keyword=value pairs.
+
+        Returns:
+            Formatted keyword line.
+        """
+        tokens = tokenize_line(line)
+
+        # Merge standalone '=' tokens with neighbours: KEY = VALUE -> KEY=VALUE
+        merged: List[str] = []
+        i = 0
+        while i < len(tokens):
+            if tokens[i] == "=" and merged and i + 1 < len(tokens):
+                merged[-1] = merged[-1] + "=" + tokens[i + 1]
+                i += 2
+            else:
+                merged.append(tokens[i])
+                i += 1
+
+        formatted_tokens: List[str] = []
+        for token in merged:
+            if "=" in token:
+                key, value = token.split("=", 1)
+                key_clean = key.strip().upper()
+                val_clean = value.strip()
+                # Uppercase value unless it is quoted
+                if not (val_clean.startswith('"') or val_clean.startswith("'")):
+                    val_clean = val_clean.upper()
+                formatted_tokens.append(f"{key_clean}={val_clean}")
+            else:
+                formatted_tokens.append(token.strip().upper())
+
+        return " ".join(formatted_tokens)
+
+
+# Alias for convenience
+FormattingProvider = GamessFormattingProvider
+
+
+def get_formatting_provider(server: LanguageServer) -> GamessFormattingProvider:
+    """Create a formatting provider instance.
+
+    Args:
+        server: The language server instance.
+
+    Returns:
+        Formatting provider instance.
+    """
+    return GamessFormattingProvider(server)

--- a/src/gamess_lsp/server.py
+++ b/src/gamess_lsp/server.py
@@ -22,6 +22,7 @@ from lsprotocol.types import (
     DidChangeTextDocumentParams,
     DidOpenTextDocumentParams,
     DocumentFormattingParams,
+    DocumentRangeFormattingParams,
     DocumentSymbolParams,
     Hover,
     HoverParams,
@@ -43,6 +44,7 @@ from pygls.server import LanguageServer
 from pygls.workspace import Document
 
 from .features.diagnostic import DiagnosticProvider
+from .features.formatting import FormattingProvider
 from .features.typecheck import TypecheckProvider
 from .features.lint import LintProvider
 from .keywords import GAMESS_GROUPS, GAMESS_KEYWORDS
@@ -115,6 +117,7 @@ document_cache = DocumentCache()
 # Create diagnostic provider instance
 diagnostic_provider = DiagnosticProvider(server)
 lint_provider = LintProvider(server)
+formatting_provider = FormattingProvider(server)
 
 
 def _is_valid_document_uri(uri: str) -> bool:
@@ -559,77 +562,21 @@ def diagnostic(params: Any) -> List[Diagnostic]:
 def formatting(params: DocumentFormattingParams) -> List[TextEdit]:
     """Handle document formatting requests."""
     doc = server.workspace.get_text_document(params.text_document.uri)
-    content = doc.source
-    lines = content.split("\n")
+    return formatting_provider.format_document(doc.source, params)
 
-    formatted_lines = []
-    in_group = False
-    indent = "  "
 
-    for line in lines:
-        stripped = line.strip()
-
-        if not stripped:
-            formatted_lines.append("")
-            continue
-
-        if stripped.startswith("!"):
-            formatted_lines.append(stripped)
-            continue
-
-        if stripped.startswith("$") and not re.match(r"^\$END\b", stripped, re.IGNORECASE):
-            match = re.match(r"^\$([A-Za-z_][A-Za-z0-9_]*)\s*(.*)", stripped)
-            if match:
-                group_name = match.group(1).upper()
-                rest = match.group(2).strip()
-
-                if rest and not rest.startswith("$"):
-                    formatted_lines.append(f"${group_name}")
-                    in_group = True
-                    keywords = _format_keywords(rest)
-                    formatted_lines.append(f"{indent}{keywords}")
-                else:
-                    formatted_lines.append(f"${group_name}")
-                    in_group = True
-
-                    if rest.upper().startswith("$END"):
-                        in_group = False
-                        formatted_lines.append("$END")
-        elif re.match(r"^\$END\b", stripped, re.IGNORECASE):
-            in_group = False
-            formatted_lines.append("$END")
-        elif in_group:
-            if "=" in stripped and not stripped.startswith("!"):
-                formatted_keywords = _format_keywords(stripped)
-                formatted_lines.append(f"{indent}{formatted_keywords}")
-            else:
-                formatted_lines.append(f"{indent}{stripped}")
-        else:
-            formatted_lines.append(stripped)
-
-    return [
-        TextEdit(
-            range=Range(
-                start=Position(line=0, character=0), end=Position(line=len(lines), character=0)
-            ),
-            new_text="\n".join(formatted_lines),
-        )
-    ]
+@server.feature("textDocument/rangeFormatting")
+def range_formatting(params: DocumentRangeFormattingParams) -> List[TextEdit]:
+    """Handle range formatting requests."""
+    doc = server.workspace.get_text_document(params.text_document.uri)
+    return formatting_provider.format_range(doc.source, params)
 
 
 def _format_keywords(line: str) -> str:
     """Format a line of keyword=value pairs."""
-    tokens = tokenize_line(line)
+    from .features.formatting import GamessFormattingProvider
 
-    formatted_tokens = []
-    for token in tokens:
-        if "=" in token:
-            key, value = token.split("=", 1)
-            formatted_tokens.append(f"{key.strip()}={value.strip()}")
-        else:
-            formatted_tokens.append(token.strip())
-
-    return " ".join(formatted_tokens)
+    return GamessFormattingProvider._format_keywords(line)
 
 
 @server.feature("textDocument/documentSymbol")

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -2,50 +2,84 @@
 
 from unittest.mock import MagicMock, patch
 
-from lsprotocol.types import DocumentFormattingParams, FormattingOptions, TextDocumentIdentifier
+from lsprotocol.types import (
+    DocumentFormattingParams,
+    DocumentRangeFormattingParams,
+    FormattingOptions,
+    Position,
+    Range,
+    TextDocumentIdentifier,
+)
 
-from gamess_lsp.server import _format_keywords, formatting
+from gamess_lsp.features.formatting import GamessFormattingProvider
+from gamess_lsp.server import _format_keywords, formatting, range_formatting
+
+
+# ---------------------------------------------------------------------------
+# Helper to build params
+# ---------------------------------------------------------------------------
+
+def _fmt_params(
+    uri: str = "file:///test.inp",
+    tab_size: int = 2,
+    insert_spaces: bool = True,
+) -> DocumentFormattingParams:
+    return DocumentFormattingParams(
+        text_document=TextDocumentIdentifier(uri=uri),
+        options=FormattingOptions(tab_size=tab_size, insert_spaces=insert_spaces),
+    )
+
+
+def _range_params(
+    start_line: int,
+    end_line: int,
+    uri: str = "file:///test.inp",
+    tab_size: int = 2,
+    insert_spaces: bool = True,
+) -> DocumentRangeFormattingParams:
+    return DocumentRangeFormattingParams(
+        text_document=TextDocumentIdentifier(uri=uri),
+        range=Range(
+            start=Position(line=start_line, character=0),
+            end=Position(line=end_line, character=0),
+        ),
+        options=FormattingOptions(tab_size=tab_size, insert_spaces=insert_spaces),
+    )
+
+
+def _mock_doc(source: str) -> MagicMock:
+    doc = MagicMock()
+    doc.source = source
+    doc.lines = source.split("\n")
+    return doc
+
+
+# ===========================================================================
+# Document formatting via server handler
+# ===========================================================================
 
 
 class TestFormatting:
-    """Test document formatting feature."""
+    """Test document formatting via the server handler."""
 
     @patch("gamess_lsp.server.server")
     def test_format_simple_document(self, mock_server):
         """Test formatting a simple document."""
-        mock_doc = MagicMock()
-        mock_doc.source = "$CONTRL SCFTYP=RHF $END"
-        mock_doc.lines = ["$CONTRL SCFTYP=RHF $END"]
+        mock_doc = _mock_doc("$CONTRL SCFTYP=RHF $END")
         mock_server.workspace.get_text_document.return_value = mock_doc
 
-        params = DocumentFormattingParams(
-            text_document=TextDocumentIdentifier(uri="file:///test.inp"),
-            options=FormattingOptions(tab_size=2, insert_spaces=True),
-        )
-
-        result = formatting(params)
+        result = formatting(_fmt_params())
         assert len(result) == 1
-        # Should format the entire document
         assert isinstance(result[0].new_text, str)
 
     @patch("gamess_lsp.server.server")
     def test_format_multiline_document(self, mock_server):
         """Test formatting a multiline document."""
-        content = """$CONTRL
-SCFTYP=RHF
-RUNTYP=ENERGY
-$END"""
-        mock_doc = MagicMock()
-        mock_doc.source = content
-        mock_doc.lines = content.split("\n")
+        content = "$CONTRL\nSCFTYP=RHF\nRUNTYP=ENERGY\n$END"
+        mock_doc = _mock_doc(content)
         mock_server.workspace.get_text_document.return_value = mock_doc
 
-        params = DocumentFormattingParams(
-            text_document=TextDocumentIdentifier(uri="file:///test.inp"),
-            options=FormattingOptions(tab_size=2, insert_spaces=True),
-        )
-
-        result = formatting(params)
+        result = formatting(_fmt_params())
         assert len(result) == 1
         formatted = result[0].new_text
         assert "$CONTRL" in formatted
@@ -54,64 +88,387 @@ $END"""
     @patch("gamess_lsp.server.server")
     def test_format_with_comments(self, mock_server):
         """Test formatting preserves comments."""
-        content = """! This is a comment
-$CONTRL SCFTYP=RHF $END
-! Another comment"""
-        mock_doc = MagicMock()
-        mock_doc.source = content
-        mock_doc.lines = content.split("\n")
+        content = "! This is a comment\n$CONTRL SCFTYP=RHF $END\n! Another comment"
+        mock_doc = _mock_doc(content)
         mock_server.workspace.get_text_document.return_value = mock_doc
 
-        params = DocumentFormattingParams(
-            text_document=TextDocumentIdentifier(uri="file:///test.inp"),
-            options=FormattingOptions(tab_size=2, insert_spaces=True),
-        )
-
-        result = formatting(params)
+        result = formatting(_fmt_params())
         assert len(result) == 1
         formatted = result[0].new_text
         assert "! This is a comment" in formatted
 
     @patch("gamess_lsp.server.server")
     def test_format_empty_document(self, mock_server):
-        """Test formatting an empty document."""
-        mock_doc = MagicMock()
-        mock_doc.source = ""
-        mock_doc.lines = []
+        """Formatting an empty document returns no edits (nothing to change)."""
+        mock_doc = _mock_doc("")
         mock_server.workspace.get_text_document.return_value = mock_doc
 
-        params = DocumentFormattingParams(
-            text_document=TextDocumentIdentifier(uri="file:///test.inp"),
-            options=FormattingOptions(tab_size=2, insert_spaces=True),
-        )
+        result = formatting(_fmt_params())
+        # Empty input produces empty output -> no edit needed
+        assert result == []
 
-        result = formatting(params)
+
+# ===========================================================================
+# FormattingProvider unit tests
+# ===========================================================================
+
+
+class TestFormattingProvider:
+    """Test the FormattingProvider class directly."""
+
+    def setup_method(self):
+        self.provider = GamessFormattingProvider(server=MagicMock())
+
+    # -- document formatting --------------------------------------------------
+
+    def test_format_simple_group(self):
+        """Format a single-group document."""
+        text = "$CONTRL\nSCFTYP=RHF\nRUNTYP=ENERGY\n$END"
+        result = self.provider.format_document(text, _fmt_params())
         assert len(result) == 1
-        assert result[0].new_text == ""
+        formatted = result[0].new_text
+        assert formatted.startswith("$CONTRL\n")
+        assert formatted.endswith("$END")
+        assert "  SCFTYP=RHF" in formatted
+        assert "  RUNTYP=ENERGY" in formatted
+
+    def test_format_uppercases_keywords(self):
+        """Keywords are uppercased during formatting."""
+        text = "$contrl\nscftyp=rhf\n$end"
+        result = self.provider.format_document(text, _fmt_params())
+        formatted = result[0].new_text
+        assert "$CONTRL" in formatted
+        assert "SCFTYP=RHF" in formatted
+        assert "$END" in formatted
+
+    def test_format_uppercases_group_names(self):
+        """Group names are uppercased."""
+        text = "$basis\ngbasIS=CC-PVDZ\n$end"
+        result = self.provider.format_document(text, _fmt_params())
+        formatted = result[0].new_text
+        assert "$BASIS" in formatted
+        assert "GBASIS=CC-PVDZ" in formatted
+
+    def test_format_preserves_comments(self):
+        """Comments are preserved unchanged."""
+        text = "! My calc\n$CONTRL\nSCFTYP=RHF\n$END\n! trailing"
+        result = self.provider.format_document(text, _fmt_params())
+        formatted = result[0].new_text
+        assert "! My calc" in formatted
+        assert "! trailing" in formatted
+
+    def test_format_preserves_blank_lines(self):
+        """Blank lines are preserved."""
+        text = "$CONTRL\nSCFTYP=RHF\n\n$END"
+        result = self.provider.format_document(text, _fmt_params())
+        formatted = result[0].new_text
+        assert "\n\n" in formatted
+
+    def test_format_multiple_groups(self):
+        """Multiple groups are formatted with proper indentation."""
+        text = "$CONTRL\nSCFTYP=RHF RUNTYP=ENERGY\n$END\n$BASIS\nGBASIS=STO NGAUSS=3\n$END"
+        result = self.provider.format_document(text, _fmt_params())
+        formatted = result[0].new_text
+        lines = formatted.split("\n")
+        assert lines[0] == "$CONTRL"
+        assert lines[1] == "  SCFTYP=RHF RUNTYP=ENERGY"
+        assert lines[2] == "$END"
+        assert lines[3] == "$BASIS"
+        assert lines[4] == "  GBASIS=STO NGAUSS=3"
+        assert lines[5] == "$END"
+
+    def test_format_data_group_preserves_geometry(self):
+        """$DATA group content is preserved with indentation."""
+        text = "$DATA\nWater molecule\nCnv 2\n\nO     8.0   0.0  0.0  0.117\nH     1.0   0.0  0.757 -0.470\n$END"
+        result = self.provider.format_document(text, _fmt_params())
+        formatted = result[0].new_text
+        assert "  Water molecule" in formatted
+        assert "  Cnv 2" in formatted
+        assert "  O     8.0   0.0  0.0  0.117" in formatted
+
+    def test_format_inline_keywords_after_group(self):
+        """Inline keywords after group name are placed on next line."""
+        text = "$CONTRL SCFTYP=RHF\n$END"
+        result = self.provider.format_document(text, _fmt_params())
+        formatted = result[0].new_text
+        lines = formatted.split("\n")
+        assert lines[0] == "$CONTRL"
+        assert lines[1] == "  SCFTYP=RHF"
+
+    def test_format_preserves_trailing_newline(self):
+        """Trailing newline is preserved."""
+        text = "$CONTRL\nSCFTYP=RHF\n$END\n"
+        result = self.provider.format_document(text, _fmt_params())
+        formatted = result[0].new_text
+        assert formatted.endswith("\n")
+
+    def test_format_no_trailing_newline(self):
+        """No trailing newline when original lacks one."""
+        text = "$CONTRL\nSCFTYP=RHF\n$END"
+        result = self.provider.format_document(text, _fmt_params())
+        formatted = result[0].new_text
+        assert not formatted.endswith("\n")
+
+    def test_format_already_formatted_returns_empty(self):
+        """Already-formatted document returns no edits."""
+        text = "$CONTRL\n  SCFTYP=RHF\n$END"
+        result = self.provider.format_document(text, _fmt_params())
+        assert result == []
+
+    def test_format_tab_indent_option(self):
+        """Tab indent option is respected."""
+        text = "$CONTRL\nSCFTYP=RHF\n$END"
+        params = _fmt_params(tab_size=4, insert_spaces=False)
+        result = self.provider.format_document(text, params)
+        formatted = result[0].new_text
+        assert "\tSCFTYP=RHF" in formatted
+
+    def test_format_custom_tab_size(self):
+        """Custom tab_size produces correct number of spaces."""
+        text = "$CONTRL\nSCFTYP=RHF\n$END"
+        params = _fmt_params(tab_size=4)
+        result = self.provider.format_document(text, params)
+        formatted = result[0].new_text
+        assert "    SCFTYP=RHF" in formatted
+
+    def test_format_normalizes_spaces_around_equals(self):
+        """Spaces around equals signs are normalized."""
+        text = "$CONTRL\nSCFTYP = RHF  RUNTYP = ENERGY\n$END"
+        result = self.provider.format_document(text, _fmt_params())
+        formatted = result[0].new_text
+        assert "SCFTYP=RHF" in formatted
+        assert "RUNTYP=ENERGY" in formatted
+
+    # -- $END edge cases ------------------------------------------------------
+
+    def test_format_dollar_end_case_insensitive(self):
+        """$end, $End, etc. are all treated as $END."""
+        text = "$CONTRL\nSCFTYP=RHF\n$end"
+        result = self.provider.format_document(text, _fmt_params())
+        formatted = result[0].new_text
+        assert "$END" in formatted
+
+    def test_format_inline_dollar_end(self):
+        """Inline $END after group name produces group + $END."""
+        text = "$CONTRL $END"
+        result = self.provider.format_document(text, _fmt_params())
+        formatted = result[0].new_text
+        lines = formatted.split("\n")
+        assert "$CONTRL" in lines[0]
+        assert "$END" in lines[1]
+
+    # -- malformed input ------------------------------------------------------
+
+    def test_format_unclosed_group(self):
+        """Unclosed group is still formatted (indent preserved)."""
+        text = "$CONTRL\nSCFTYP=RHF"
+        result = self.provider.format_document(text, _fmt_params())
+        formatted = result[0].new_text
+        assert "$CONTRL" in formatted
+        assert "SCFTYP=RHF" in formatted
+
+    def test_format_lone_dollar_end(self):
+        """$END without matching group is handled gracefully."""
+        text = "$END"
+        result = self.provider.format_document(text, _fmt_params())
+        # $END with no open group: formatted == original, so no edits
+        assert result == []
+
+    # -- idempotency ----------------------------------------------------------
+
+    def test_format_idempotent(self):
+        """Formatting twice produces the same output."""
+        text = "$CONTRL\n  scftyp=rhf   runtyp=ENERGY\n$end\n$BASIS\n  GBASIS=CC-PVDZ\n$END"
+        result1 = self.provider.format_document(text, _fmt_params())
+        first_pass = result1[0].new_text
+
+        result2 = self.provider.format_document(first_pass, _fmt_params())
+        # Second pass should produce no edits (already formatted)
+        assert result2 == []
+
+    def test_format_idempotent_complex(self):
+        """Idempotency with comments, blank lines, multiple groups, $DATA."""
+        text = """! Complex input
+$CONTRL
+SCFTYP=RHF RUNTYP=OPTIMIZE
+$END
+
+$BASIS
+GBASIS=CC-PVDZ
+$END
+
+$DATA
+Water
+C1
+
+O     8.0   0.0  0.0  0.117
+H     1.0   0.0  0.757 -0.470
+$END"""
+        first = self.provider.format_document(text, _fmt_params())[0].new_text
+        second_result = self.provider.format_document(first, _fmt_params())
+        assert second_result == [], f"Not idempotent: got {second_result}"
+
+
+# ===========================================================================
+# Range formatting
+# ===========================================================================
+
+
+class TestRangeFormatting:
+    """Test range formatting via the server handler."""
+
+    def setup_method(self):
+        self.provider = GamessFormattingProvider(server=MagicMock())
+
+    @patch("gamess_lsp.server.server")
+    def test_range_format_handler(self, mock_server):
+        """Range formatting handler delegates to provider."""
+        content = "$CONTRL\n  scftyp=rhf\n  RUNTYP=ENERGY\n$END"
+        mock_doc = _mock_doc(content)
+        mock_server.workspace.get_text_document.return_value = mock_doc
+
+        result = range_formatting(_range_params(1, 2))
+        assert isinstance(result, list)
+        for edit in result:
+            assert hasattr(edit, "new_text")
+            assert hasattr(edit, "range")
+
+    def test_range_format_only_selected_lines(self):
+        """Range formatting only changes lines within the range."""
+        text = "$CONTRL\nscftyp=rhf\nRUNTYP=ENERGY\n$END"
+        result = self.provider.format_range(text, _range_params(1, 1))
+        # Only line 1 should change
+        for edit in result:
+            assert edit.range.start.line >= 1
+            assert edit.range.end.line <= 1
+            assert "SCFTYP=RHF" in edit.new_text
+
+    def test_range_format_respects_group_indent(self):
+        """Range formatting computes correct indent from document context."""
+        text = "$CONTRL\nscftyp=rhf\nRUNTYP=ENERGY\n$END"
+        result = self.provider.format_range(text, _range_params(1, 2))
+        for edit in result:
+            assert edit.new_text.startswith("  ")
+
+    def test_range_format_outside_group(self):
+        """Range formatting on lines outside a group uses zero indent."""
+        text = "! top comment\n$CONTRL\nSCFTYP=RHF\n$END"
+        result = self.provider.format_range(text, _range_params(0, 0))
+        # Comment line should be preserved as-is
+        if result:
+            assert "! top comment" in result[0].new_text
+
+    def test_range_format_empty_range(self):
+        """Range formatting with invalid range returns no edits."""
+        text = "$CONTRL\nSCFTYP=RHF\n$END"
+        result = self.provider.format_range(
+            text, _range_params(5, 3)  # start > end
+        )
+        assert result == []
+
+    def test_range_format_clamps_to_document(self):
+        """Range formatting clamps to document boundaries."""
+        text = "$CONTRL\nSCFTYP=RHF\n$END"
+        result = self.provider.format_range(
+            text, _range_params(0, 100)  # end beyond document
+        )
+        assert isinstance(result, list)
+
+    def test_range_format_unchanged_returns_empty(self):
+        """Range formatting returns empty list if lines are already formatted."""
+        text = "$CONTRL\n  SCFTYP=RHF\n$END"
+        result = self.provider.format_range(text, _range_params(1, 1))
+        assert result == []
+
+
+# ===========================================================================
+# _format_keywords helper
+# ===========================================================================
 
 
 class TestFormatKeywords:
     """Test _format_keywords helper function."""
 
     def test_format_single_keyword(self):
-        """Test formatting a single keyword."""
         result = _format_keywords("SCFTYP=RHF")
         assert result == "SCFTYP=RHF"
 
     def test_format_multiple_keywords(self):
-        """Test formatting multiple keywords."""
         result = _format_keywords("SCFTYP=RHF RUNTYP=ENERGY")
         assert "SCFTYP=RHF" in result
         assert "RUNTYP=ENERGY" in result
 
     def test_format_quoted_values(self):
-        """Test formatting with quoted values."""
         result = _format_keywords('EXETYP="CHECK"')
         assert 'EXETYP="CHECK"' in result
 
     def test_format_with_extra_spaces(self):
-        """Test formatting normalizes spaces."""
         result = _format_keywords("SCFTYP  =  RHF")
-        # The formatter preserves the key=value format
-        assert "SCFTYP" in result
-        assert "RHF" in result
+        assert "SCFTYP=RHF" in result
+
+    def test_format_uppercases_keywords(self):
+        result = _format_keywords("scftyp=rhf")
+        assert "SCFTYP=RHF" == result
+
+    def test_format_preserves_value_case(self):
+        """Values that are not standard keywords are preserved."""
+        result = _format_keywords("GBASIS=CC-PVDZ")
+        assert "GBASIS=CC-PVDZ" == result
+
+
+# ===========================================================================
+# Internal helper unit tests
+# ===========================================================================
+
+
+class TestInternalHelpers:
+    """Test internal helper methods of FormattingProvider."""
+
+    def setup_method(self):
+        self.provider = GamessFormattingProvider(server=MagicMock())
+
+    def test_compute_context_at_line_basic(self):
+        """Context computation tracks group nesting."""
+        lines = ["$CONTRL", "SCFTYP=RHF", "$END", "$BASIS", "GBASIS=STO"]
+        level, in_data = GamessFormattingProvider._compute_context_at_line(lines, 4)
+        assert level == 1
+        assert in_data is False
+
+    def test_compute_context_at_line_data_group(self):
+        """Context computation tracks $DATA group."""
+        lines = ["$DATA", "Title", "C1", "O 8.0 0.0 0.0 0.0"]
+        level, in_data = GamessFormattingProvider._compute_context_at_line(lines, 3)
+        assert level == 1
+        assert in_data is True
+
+    def test_compute_context_at_line_after_end(self):
+        """Context computation resets after $END."""
+        lines = ["$CONTRL", "SCFTYP=RHF", "$END"]
+        level, in_data = GamessFormattingProvider._compute_context_at_line(lines, 3)
+        assert level == 0
+        assert in_data is False
+
+    def test_update_context_group_start(self):
+        level, in_data = GamessFormattingProvider._update_context("$BASIS", 0, False)
+        assert level == 1
+        assert in_data is False
+
+    def test_update_context_data_start(self):
+        level, in_data = GamessFormattingProvider._update_context("$DATA", 0, False)
+        assert level == 1
+        assert in_data is True
+
+    def test_update_context_end(self):
+        level, in_data = GamessFormattingProvider._update_context("$END", 1, True)
+        assert level == 0
+        assert in_data is False
+
+    def test_update_context_blank_line(self):
+        level, in_data = GamessFormattingProvider._update_context("", 2, False)
+        assert level == 2
+        assert in_data is False
+
+    def test_update_context_comment(self):
+        level, in_data = GamessFormattingProvider._update_context("! comment", 1, True)
+        assert level == 1
+        assert in_data is True


### PR DESCRIPTION
Closes #40

## Summary

Implements LSP document and range formatting for GAMESS input files.

### Changes

- **New `FormattingProvider`** in `src/gamess_lsp/features/formatting.py`:
  - `format_document()` — formats entire document, returns `list[TextEdit]`
  - `format_range()` — formats selected line range with correct indent context
  - Uppercases group names and keyword keys/values (GAMESS convention)
  - Normalizes spacing around `=` signs (handles `KEY = VALUE` style)
  - Preserves comments (`!`), blank lines, and $DATA section content
  - Idempotent across representative inputs

- **Server registration** in `src/gamess_lsp/server.py`:
  - `textDocument/formatting` delegates to provider
  - `textDocument/rangeFormatting` — new handler
  - Inline formatting logic replaced by provider call

- **45 tests** in `tests/test_formatting.py`:
  - Document formatting: groups, comments, blank lines, $DATA, inline keywords
  - Range formatting: context computation, partial ranges, boundary handling
  - Idempotency verification
  - Internal helper unit tests
  - Edge cases: malformed input, lone $END, unclosed groups

### Acceptance Criteria Met

- [x] LSP server advertises formatting capabilities
- [x] Formatting is idempotent across representative fixtures
- [x] Tests cover nested sections, comments, blank lines, malformed input, and partial ranges