### PR TITLE
Package gamess for pip and pluggable skill export

### DIFF
--- a/.github/workflows/testpypi-release.yml
+++ b/.github/workflows/testpypi-release.yml
@@ -1,0 +1,118 @@
+name: TestPyPI release
+
+on:
+  push:
+    tags:
+      - "testpypi-v*"
+  workflow_dispatch:
+    inputs:
+      publish_to_testpypi:
+        description: "Publish the built artifacts to TestPyPI"
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  build:
+    name: Build artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js
+        if: ${{ hashFiles('package.json') != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Set up Rust
+        if: ${{ hashFiles('Cargo.toml') != '' }}
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Check tag version
+        if: ${{ startsWith(github.ref, 'refs/tags/testpypi-v') }}
+        run: |
+          python - "${GITHUB_REF_NAME#testpypi-v}" <<'PY'
+          from pathlib import Path
+          import re
+          import sys
+          import tomllib
+
+          expected = sys.argv[1]
+          data = tomllib.loads(Path("pyproject.toml").read_text())
+          actual = (
+              data.get("project", {}).get("version")
+              or data.get("tool", {}).get("poetry", {}).get("version")
+          )
+          if actual is None and Path("setup.py").exists():
+              match = re.search(
+                  r"version\s*=\s*['\"]([^'\"]+)['\"]",
+                  Path("setup.py").read_text(),
+              )
+              actual = match.group(1) if match else None
+          if actual != expected:
+              raise SystemExit(
+                  f"tag version {expected!r} does not match package version {actual!r}"
+              )
+          PY
+
+      - name: Build artifacts
+        run: scripts/build-testpypi-artifacts.sh
+
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+
+  publish:
+    name: Publish to TestPyPI
+    needs: build
+    if: >-
+      ${{
+        startsWith(github.ref, 'refs/tags/testpypi-v')
+        || (github.event_name == 'workflow_dispatch'
+            && inputs.publish_to_testpypi)
+      }}
+    runs-on: ubuntu-latest
+    environment: testpypi
+    env:
+      TEST_PYPI_API_TOKEN: ${{ secrets.TEST_PYPI_API_TOKEN }}
+    steps:
+      - name: Download dist artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist
+
+      - name: Publish to TestPyPI with token secret
+        if: ${{ env.TEST_PYPI_API_TOKEN != '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+          password: ${{ env.TEST_PYPI_API_TOKEN }}
+          skip-existing: true
+          attestations: false
+
+      - name: Publish to TestPyPI with trusted publishing
+        if: ${{ env.TEST_PYPI_API_TOKEN == '' }}
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          packages-dir: dist/
+          skip-existing: true
+          attestations: false

--- a/docs/testpypi-release.md
+++ b/docs/testpypi-release.md
@@ -1,0 +1,64 @@
+# TestPyPI release workflow
+
+This repository publishes prerelease artifacts to TestPyPI only. Do not use this
+workflow for production PyPI releases.
+
+## Local build
+
+```bash
+scripts/build-testpypi-artifacts.sh
+```
+
+The build script writes `dist/`, runs package-specific build steps, validates the
+wheel and sdist with `twine check`, and verifies that the pluggable `skill/`
+metadata is present in the distribution artifacts. CIF repositories use the
+committed JavaScript bundle by default; set `CIF_REBUILD_JS=1` to refresh it
+before building.
+
+## Local TestPyPI upload
+
+Create a TestPyPI API token outside the repository, then run:
+
+```bash
+export TWINE_USERNAME=__token__
+export TWINE_PASSWORD='pypi-...'
+scripts/upload-testpypi.sh
+```
+
+The script defaults to `https://test.pypi.org/legacy/`. Override
+`TWINE_REPOSITORY_URL` only for a compatible private index.
+
+## GitHub tag release
+
+The workflow `.github/workflows/testpypi-release.yml` builds on every
+`testpypi-v*` tag. The tag version must match the package metadata.
+
+For the current prerelease:
+
+```bash
+git tag testpypi-v0.1.1rc1
+git push origin testpypi-v0.1.1rc1
+```
+
+The workflow can publish with either:
+
+- `TEST_PYPI_API_TOKEN` repository secret, using a TestPyPI token; or
+- TestPyPI Trusted Publishing configured for this repository, the
+  `testpypi-release.yml` workflow, and the `testpypi` GitHub environment.
+
+Manual runs are supported from the GitHub Actions tab. Leave
+`publish_to_testpypi=false` for build-only validation, or set it to `true` to
+publish.
+
+## Test install
+
+After publishing:
+
+```bash
+python -m venv /tmp/gamess-lsp-testpypi
+/tmp/gamess-lsp-testpypi/bin/python -m pip install --upgrade pip
+/tmp/gamess-lsp-testpypi/bin/pip install \
+  --index-url https://test.pypi.org/simple/ \
+  --extra-index-url https://pypi.org/simple/ \
+  gamess-lsp==0.1.1rc1
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gamess-lsp"
-version = "0.1.0"
+version = "0.1.1rc1"
 description = "Language Server Protocol for GAMESS input files"
 readme = "README.md"
 license = {file = "LICENSE"}
@@ -31,6 +31,10 @@ dev = [
 [project.scripts]
 gamess-lsp = "gamess_lsp.server:main"
 gamess-lsp-tool = "gamess_lsp.tool:main"
+
+
+[tool.hatch.build.force-include]
+"skill" = "skill"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/gamess_lsp"]

--- a/scripts/build-testpypi-artifacts.sh
+++ b/scripts/build-testpypi-artifacts.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+rm -rf dist
+mkdir -p dist
+
+if [[ -f pyproject.toml ]] && grep -q 'build-backend = "maturin"' pyproject.toml; then
+  export CARGO_BUILD_JOBS="${CARGO_BUILD_JOBS:-2}"
+  uvx maturin build --release --out dist
+  uvx maturin sdist --out dist
+else
+  if [[ -f package.json && -d server/src && -d src/cif_lsp ]]; then
+    if [[ "${CIF_REBUILD_JS:-0}" != "1" \
+      && -s src/cif_lsp/js/cifLspTool.cjs \
+      && -s src/cif_lsp/js/server.cjs ]]; then
+      echo "Using existing bundled CIF JavaScript files."
+    else
+    npm ci --ignore-scripts
+    npm ci --prefix client
+    npm ci --prefix server
+    npm run compile
+    mkdir -p src/cif_lsp/js
+    npx --yes esbuild server/out/cifLspTool.js \
+      --bundle \
+      --platform=node \
+      --format=cjs \
+      --outfile=src/cif_lsp/js/cifLspTool.cjs
+    npx --yes esbuild server/out/server.js \
+      --bundle \
+      --platform=node \
+      --format=cjs \
+      --banner:js='#!/usr/bin/env node' \
+      --outfile=src/cif_lsp/js/server.cjs
+    chmod 755 src/cif_lsp/js/cifLspTool.cjs
+    fi
+  fi
+  uvx --from build python -m build --outdir dist
+fi
+
+uvx twine check dist/*
+
+"${PYTHON:-python3}" - <<'PY'
+from pathlib import Path
+import sys
+import tarfile
+import zipfile
+
+dist = Path("dist")
+wheels = sorted(dist.glob("*.whl"))
+sdists = sorted(dist.glob("*.tar.gz"))
+if not wheels or not sdists:
+    raise SystemExit("dist must contain at least one wheel and one sdist")
+
+for wheel in wheels:
+    with zipfile.ZipFile(wheel) as archive:
+        names = archive.namelist()
+    has_skill = any(name.endswith("skill/skill.yaml") for name in names)
+    has_embedded_skill_cli = any(
+        name.endswith(".data/scripts/lammps-lsp-tool")
+        or name.endswith("/lammps-lsp-tool")
+        for name in names
+    )
+    if not has_skill and not has_embedded_skill_cli:
+        raise SystemExit(f"{wheel} does not expose skill metadata")
+
+for sdist in sdists:
+    with tarfile.open(sdist) as archive:
+        names = archive.getnames()
+    if not any(name.endswith("/skill/skill.yaml") for name in names):
+        raise SystemExit(f"{sdist} does not include skill/skill.yaml")
+
+print("dist artifact checks passed", file=sys.stderr)
+PY

--- a/scripts/upload-testpypi.sh
+++ b/scripts/upload-testpypi.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(git rev-parse --show-toplevel)"
+cd "$ROOT_DIR"
+
+if ! compgen -G "dist/*" >/dev/null; then
+  scripts/build-testpypi-artifacts.sh
+fi
+
+if [[ "${TWINE_USERNAME:-}" == "" || "${TWINE_PASSWORD:-}" == "" ]]; then
+  cat >&2 <<'EOF'
+Missing local TestPyPI credentials.
+
+Use a TestPyPI API token:
+  export TWINE_USERNAME=__token__
+  export TWINE_PASSWORD='pypi-...'
+
+GitHub Actions can publish without local credentials when TestPyPI Trusted
+Publishing is configured for .github/workflows/testpypi-release.yml.
+EOF
+  exit 2
+fi
+
+uvx twine upload \
+  --repository-url "${TWINE_REPOSITORY_URL:-https://test.pypi.org/legacy/}" \
+  "$@" \
+  dist/*

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: gamess
+description: "GAMESS input preflight for generated .inp job files."
+---
+
+# GAMESS LSP Skill
+
+Use this skill when preparing, repairing, or reviewing GAMESS input files before a run. It provides an installable language server and an agent-facing CLI that reports machine-readable diagnostics.
+
+## Scope
+
+- Input patterns: *.inp
+- Server command: `gamess-lsp`
+- Agent CLI: `gamess-lsp-tool`
+- Diagnostic contract: `DiagnosticEnvelope/v1`
+
+## Installing the checker
+
+```bash
+pip install gamess-lsp
+```
+
+This installs the `gamess-lsp` language server and the `gamess-lsp-tool` agent CLI from the `gamess-lsp` Python package.
+
+## Useful inspection commands
+
+```bash
+gamess-lsp-tool capabilities
+gamess-lsp-tool skill-spec --format json
+gamess-lsp-tool skill-export --output ./skill
+gamess-lsp-tool check <input-file-or-dir> --format json
+gamess-lsp-tool context <input-file-or-dir> --line 0 --character 0 --format json
+gamess-lsp-tool hover <input-file-or-dir> --line 0 --character 0 --format json
+gamess-lsp-tool complete <input-file-or-dir> --line 0 --character 0 --format json
+gamess-lsp-tool symbols <input-file-or-dir> --format json
+gamess-lsp-tool fix <input-file-or-dir> --line 0 --character 0 --format json
+```
+
+`fix` is advisory and must be treated as a preview. Do not blindly apply a repair without preserving the user's scientific intent.
+
+## Validation gate
+
+Before saying generated inputs are ready, run:
+
+```bash
+gamess-lsp-tool check <input-file-or-dir> --format json --fail-on-blocking
+```
+
+Report `commands`, `files_checked`, `tool_available`, `diagnostics`, `blocking_findings`, `readiness`, and `reason`.
+
+## Repair rules
+
+1. Validate first and identify the smallest blocking issue.
+2. Fix syntax or schema errors with minimal edits.
+3. Preserve scientific settings unless the user explicitly asks to redesign them.
+4. Re-run the checker after every edit.
+5. Separate syntax, schema, semantic, and runtime-log diagnostics in the final report.

--- a/skill/references/README.md
+++ b/skill/references/README.md
@@ -1,0 +1,3 @@
+# GAMESS LSP Skill References
+
+This directory is reserved for small examples, rule notes, and templates that are safe to ship with the Python package. Keep large manuals and generated indexes in the LSP package proper, not in the pluggable skill artifact.

--- a/skill/skill.yaml
+++ b/skill/skill.yaml
@@ -10,7 +10,7 @@ entrypoints:
   server: gamess-lsp
   tool: gamess-lsp-tool
 file_patterns:
-  - *.inp
+  - "*.inp"
 operations:
   - capabilities
   - check

--- a/skill/skill.yaml
+++ b/skill/skill.yaml
@@ -1,0 +1,30 @@
+schema: scientific-lsp-skill/v1
+name: gamess
+software: gamess
+display_name: GAMESS
+description: GAMESS input preflight for generated .inp job files.
+package:
+  name: gamess-lsp
+  install: pip install gamess-lsp
+entrypoints:
+  server: gamess-lsp
+  tool: gamess-lsp-tool
+file_patterns:
+  - *.inp
+operations:
+  - capabilities
+  - check
+  - context
+  - complete
+  - hover
+  - symbols
+  - fix
+diagnostic_contract: DiagnosticEnvelope/v1
+blocking_policy:
+  mode: warning-only
+  description: Use --fail-on-blocking when generated inputs must be launch-ready.
+source_provenance:
+  -
+    kind: official_docs
+    label: GAMESS input documentation
+    url: https://www.msg.chem.iastate.edu/gamess/documentation.html

--- a/src/gamess_lsp/skill_export.py
+++ b/src/gamess_lsp/skill_export.py
@@ -1,0 +1,194 @@
+"""Export the bundled pluggable skill specification."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+SKILL_SPEC_JSON = (
+    '{"schema":"scientific-lsp-skill/v1","name":"gamess","software":"gamess","dis'
+    'play_name":"GAMESS","description":"GAMESS input preflight for generated .inp'
+    ' job files.","package":{"name":"gamess-lsp","install":"pip install gamess-ls'
+    'p"},"entrypoints":{"server":"gamess-lsp","tool":"gamess-lsp-tool"},"file_pat'
+    'terns":["*.inp"],"operations":["capabilities","check","context","complete","'
+    'hover","symbols","fix"],"diagnostic_contract":"DiagnosticEnvelope/v1","block'
+    'ing_policy":{"mode":"warning-only","description":"Use --fail-on-blocking whe'
+    'n generated inputs must be launch-ready."},"source_provenance":[{"kind":"off'
+    'icial_docs","label":"GAMESS input documentation","url":"https://www.msg.chem'
+    '.iastate.edu/gamess/documentation.html"}]}'
+)
+
+SKILL_SPEC: dict[str, Any] = json.loads(SKILL_SPEC_JSON)
+
+SKILL_MD_LINES = [
+    '---',
+    'name: gamess',
+    'description: "GAMESS input preflight for generated .inp job files."',
+    '---',
+    '',
+    '# GAMESS LSP Skill',
+    '',
+    (
+        'Use this skill when preparing, repairing, or reviewing GAMESS input files be'
+        'fore a run. It provides an installable language server and an agent-facing C'
+        'LI that reports machine-readable diagnostics.'
+    ),
+    '',
+    '## Scope',
+    '',
+    '- Input patterns: *.inp',
+    '- Server command: `gamess-lsp`',
+    '- Agent CLI: `gamess-lsp-tool`',
+    '- Diagnostic contract: `DiagnosticEnvelope/v1`',
+    '',
+    '## Installing the checker',
+    '',
+    '```bash',
+    'pip install gamess-lsp',
+    '```',
+    '',
+    (
+        'This installs the `gamess-lsp` language server and the `gamess-lsp-tool` age'
+        'nt CLI from the `gamess-lsp` Python package.'
+    ),
+    '',
+    '## Useful inspection commands',
+    '',
+    '```bash',
+    'gamess-lsp-tool capabilities',
+    'gamess-lsp-tool skill-spec --format json',
+    'gamess-lsp-tool skill-export --output ./skill',
+    'gamess-lsp-tool check <input-file-or-dir> --format json',
+    (
+        'gamess-lsp-tool context <input-file-or-dir> --line 0 --character 0 --format '
+        'json'
+    ),
+    (
+        'gamess-lsp-tool hover <input-file-or-dir> --line 0 --character 0 --format js'
+        'on'
+    ),
+    (
+        'gamess-lsp-tool complete <input-file-or-dir> --line 0 --character 0 --format'
+        ' json'
+    ),
+    'gamess-lsp-tool symbols <input-file-or-dir> --format json',
+    'gamess-lsp-tool fix <input-file-or-dir> --line 0 --character 0 --format json',
+    '```',
+    '',
+    (
+        '`fix` is advisory and must be treated as a preview. Do not blindly apply a r'
+        "epair without preserving the user's scientific intent."
+    ),
+    '',
+    '## Validation gate',
+    '',
+    'Before saying generated inputs are ready, run:',
+    '',
+    '```bash',
+    'gamess-lsp-tool check <input-file-or-dir> --format json --fail-on-blocking',
+    '```',
+    '',
+    (
+        'Report `commands`, `files_checked`, `tool_available`, `diagnostics`, `blocki'
+        'ng_findings`, `readiness`, and `reason`.'
+    ),
+    '',
+    '## Repair rules',
+    '',
+    '1. Validate first and identify the smallest blocking issue.',
+    '2. Fix syntax or schema errors with minimal edits.',
+    (
+        '3. Preserve scientific settings unless the user explicitly asks to redesign '
+        'them.'
+    ),
+    '4. Re-run the checker after every edit.',
+    (
+        '5. Separate syntax, schema, semantic, and runtime-log diagnostics in the fin'
+        'al report.'
+    ),
+]
+SKILL_MD = "\n".join(SKILL_MD_LINES) + "\n"
+
+REFERENCES_README_LINES = [
+    '# GAMESS LSP Skill References',
+    '',
+    (
+        'This directory is reserved for small examples, rule notes, and templates tha'
+        't are safe to ship with the Python package. Keep large manuals and generated'
+        ' indexes in the LSP package proper, not in the pluggable skill artifact.'
+    ),
+]
+REFERENCES_README = "\n".join(REFERENCES_README_LINES) + "\n"
+
+
+def _yaml_scalar(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    if isinstance(value, (int, float)):
+        return str(value)
+    text = str(value)
+    if (
+        not text
+        or any(ch in text for ch in ":#[]{},&*?")
+        or text[0] in "-!@`"
+        or text.endswith(" ")
+        or "\n" in text
+    ):
+        return json.dumps(text, ensure_ascii=False)
+    return text
+
+
+def _to_yaml(value: object, indent: int = 0) -> str:
+    pad = " " * indent
+    if isinstance(value, dict):
+        lines: list[str] = []
+        for key, item in value.items():
+            if isinstance(item, (dict, list)):
+                lines.append(f"{pad}{key}:")
+                lines.append(_to_yaml(item, indent + 2))
+            else:
+                lines.append(f"{pad}{key}: {_yaml_scalar(item)}")
+        return "\n".join(lines)
+    if isinstance(value, list):
+        if not value:
+            return f"{pad}[]"
+        lines = []
+        for item in value:
+            if isinstance(item, (dict, list)):
+                lines.append(f"{pad}-")
+                lines.append(_to_yaml(item, indent + 2))
+            else:
+                lines.append(f"{pad}- {_yaml_scalar(item)}")
+        return "\n".join(lines)
+    return f"{pad}{_yaml_scalar(value)}"
+
+
+def skill_spec_text(output_format: str = "json") -> str:
+    if output_format == "json":
+        return json.dumps(SKILL_SPEC, indent=2, sort_keys=True, ensure_ascii=False)
+    if output_format == "yaml":
+        return _to_yaml(SKILL_SPEC) + "\n"
+    raise ValueError(f"unsupported skill spec format: {output_format}")
+
+
+def export_skill(output_dir: Path) -> dict[str, Any]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    references_dir = output_dir / "references"
+    references_dir.mkdir(exist_ok=True)
+    (output_dir / "skill.yaml").write_text(skill_spec_text("yaml"), encoding="utf-8")
+    (output_dir / "SKILL.md").write_text(SKILL_MD, encoding="utf-8")
+    (references_dir / "README.md").write_text(REFERENCES_README, encoding="utf-8")
+    return {
+        "ok": True,
+        "schema": SKILL_SPEC["schema"],
+        "name": SKILL_SPEC["name"],
+        "output_dir": str(output_dir),
+        "files": [
+            str(output_dir / "skill.yaml"),
+            str(output_dir / "SKILL.md"),
+            str(references_dir / "README.md"),
+        ],
+    }

--- a/src/gamess_lsp/tool.py
+++ b/src/gamess_lsp/tool.py
@@ -9,9 +9,9 @@ from typing import Any
 
 from .agent_operations import operation_path, with_capabilities
 from .rich_diagnostics import agent_check_payload
+from .skill_export import export_skill, skill_spec_text
 
 SOFTWARE = "gamess"
-
 
 def _capabilities_payload() -> dict[str, Any]:
     for parent in Path(__file__).resolve().parents:
@@ -52,7 +52,6 @@ def _capabilities_payload() -> dict[str, Any]:
         },
     }
 
-
 def _file_type(path: Path) -> str:
     name = path.name.upper()
     if name in {"INCAR", "POSCAR", "KPOINTS", "POTCAR", "CONTCAR"}:
@@ -60,7 +59,6 @@ def _file_type(path: Path) -> str:
     if "." in path.name:
         return path.suffix.lstrip(".").lower()
     return name.lower()
-
 
 def _collect_diagnostics(path: Path) -> list[Any]:
     from .features.diagnostic import DiagnosticProvider
@@ -70,7 +68,6 @@ def _collect_diagnostics(path: Path) -> list[Any]:
     diagnostics = list(DiagnosticProvider(None).get_diagnostics(text))  # type: ignore[arg-type]
     diagnostics.extend(LintProvider(None).lint(text))  # type: ignore[arg-type]
     return diagnostics
-
 
 def _load_intent(path: Path) -> dict[str, Any] | None:
     """Load the optional preflight intent contract for a case directory.
@@ -89,7 +86,6 @@ def _load_intent(path: Path) -> dict[str, Any] | None:
         return None
     return data if isinstance(data, dict) else None
 
-
 def _looks_like_workspace(path: Path) -> bool:
     """True when a path is a real GAMESS generated-input workspace.
 
@@ -101,7 +97,6 @@ def _looks_like_workspace(path: Path) -> bool:
     from .preflight import looks_like_gamess_workspace
 
     return looks_like_gamess_workspace(path)
-
 
 def _collect_preflight(
     path: Path, intent: dict[str, Any] | None
@@ -118,7 +113,6 @@ def _collect_preflight(
     version_assumption = resolve_version_assumption(intent)
     return diagnostics, graph.to_json(), version_assumption
 
-
 def _resolve_input_path(path: Path) -> Path:
     """Resolve the GAMESS input file from a path that may be a dir or .inp."""
     if path.is_dir():
@@ -134,7 +128,6 @@ def _resolve_input_path(path: Path) -> Path:
                 return candidate
         return path / "input.inp"
     return path
-
 
 def check_path(path: Path) -> dict[str, Any]:
     uri = path.resolve().as_uri()
@@ -162,13 +155,11 @@ def check_path(path: Path) -> dict[str, Any]:
     )
     return payload
 
-
 # Codes already emitted by the legacy analyzer that overlap with the universal
 # preflight surface. We keep the legacy emission (it carries the existing test
 # contract) and drop the duplicate preflight variant to avoid noisy double
 # reports. The preflight shape is still proven by every other fixture.
 _OVERLAP_CODES_BY_LEGACY: dict[str, set[str]] = {}
-
 
 def _dedupe_preflight(legacy: list[Any], preflight: list[Any]) -> list[Any]:
     """Drop preflight diagnostics whose finding the legacy analyzer already emitted."""
@@ -185,7 +176,6 @@ def _dedupe_preflight(legacy: list[Any], preflight: list[Any]) -> list[Any]:
         for item in preflight
         if (item.get("code") if isinstance(item, dict) else None) not in suppressed_preflight
     ]
-
 
 def preflight_path(path: Path) -> dict[str, Any]:
     """Return a preflight-only payload (universal checks, no legacy analyzer)."""
@@ -208,7 +198,6 @@ def preflight_path(path: Path) -> dict[str, Any]:
         artifacts=graph.to_json(),
     )
     return with_capabilities(payload, "preflight")
-
 
 def manifest_path(path: Path | None = None) -> dict[str, Any]:
     """Return the fleet preflight manifest.
@@ -237,7 +226,6 @@ def manifest_path(path: Path | None = None) -> dict[str, Any]:
                     if isinstance(item, dict)
                 ]
     return fleet_manifest(fixtures=fixtures)
-
 
 def log_path(path: Path) -> dict[str, Any]:
     """Return a DiagnosticEnvelope/v1 payload for a GAMESS output/log file.
@@ -297,7 +285,6 @@ def log_path(path: Path) -> dict[str, Any]:
 
     return with_capabilities(payload, "log")
 
-
 def _operation_payload(
     path: Path,
     operation: str,
@@ -314,10 +301,13 @@ def _operation_payload(
         character=character,
     )
 
-
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(prog="gamess-lsp-tool")
     subparsers = parser.add_subparsers(dest="operation", required=True)
+    skill_spec = subparsers.add_parser("skill-spec")
+    skill_spec.add_argument("--format", choices=["json", "yaml"], default="json")
+    skill_export = subparsers.add_parser("skill-export")
+    skill_export.add_argument("--output", type=Path, required=True)
     capabilities = subparsers.add_parser("capabilities")
     capabilities.add_argument("--format", choices=["json"], default="json")
     for operation in (
@@ -360,6 +350,13 @@ def main(argv: list[str] | None = None) -> int:
             sub.add_argument("--fail-on-blocking", action="store_true")
     args = parser.parse_args(argv)
 
+    if args.operation == "skill-spec":
+        print(skill_spec_text(args.format))
+        return 0
+    if args.operation == "skill-export":
+        print(json.dumps(export_skill(args.output), indent=2, sort_keys=True))
+        return 0
+
     if args.operation == "capabilities":
         print(json.dumps(_capabilities_payload(), indent=2, sort_keys=True))
         return 0
@@ -384,7 +381,6 @@ def main(argv: list[str] | None = None) -> int:
     payload = _operation_payload(args.path, args.operation, args.line, args.character)
     print(json.dumps(payload, indent=2, sort_keys=True))
     return 0
-
 
 if __name__ == "__main__":
     raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add a pluggable `skill/` manifest using `scientific-lsp-skill/v1`.
- Add `gamess-lsp-tool skill-spec --format json|yaml` and `gamess-lsp-tool skill-export --output <dir>`.
- Package the skill metadata with the wheel/sdist and bump to the next prerelease version.


## Verification
- `python -m compileall` / `cargo check` as applicable.
- Local wheel/sdist build completed.
- `twine check` passed for generated artifacts.
- Installed-wheel smoke passed for `--help`, `capabilities`, `skill-spec`, `skill-export`, and `check --format json`.

TestPyPI upload is intentionally not included in this PR because credentials are environment-provided and not stored in the repository.
