### PR TITLE
feat(provenance): add OpenQC v1 traceability report

### DIFF
--- a/reports/docstring-wiki-raw-traceability.json
+++ b/reports/docstring-wiki-raw-traceability.json
@@ -1,0 +1,388 @@
+{
+  "docstrings": [
+    {
+      "path": "src/gamess_lsp/__init__.py",
+      "symbol": "__init__",
+      "wikiPath": "wiki/entities/GAMESS.md"
+    },
+    {
+      "path": "src/gamess_lsp/agent_lsp.py",
+      "symbol": "agent_lsp",
+      "wikiPath": "wiki/entities/LSP_Server.md"
+    },
+    {
+      "path": "src/gamess_lsp/agent_operations.py",
+      "symbol": "agent_operations",
+      "wikiPath": "wiki/entities/LSP_Server.md"
+    },
+    {
+      "path": "src/gamess_lsp/constants.py",
+      "symbol": "constants",
+      "wikiPath": "wiki/synthesis/GAMESS_Input_Syntax.md"
+    },
+    {
+      "path": "src/gamess_lsp/features/__init__.py",
+      "symbol": "__init__",
+      "wikiPath": "wiki/entities/LSP_Server.md"
+    },
+    {
+      "path": "src/gamess_lsp/features/agent_api.py",
+      "symbol": "agent_api",
+      "wikiPath": "wiki/entities/OpenQC.md"
+    },
+    {
+      "path": "src/gamess_lsp/features/diagnostic.py",
+      "symbol": "diagnostic",
+      "wikiPath": "wiki/entities/Diagnostic_Engine.md"
+    },
+    {
+      "path": "src/gamess_lsp/features/formatting.py",
+      "symbol": "formatting",
+      "wikiPath": "wiki/synthesis/GAMESS_Input_Syntax.md"
+    },
+    {
+      "path": "src/gamess_lsp/features/lint.py",
+      "symbol": "lint",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "path": "src/gamess_lsp/features/regression.py",
+      "symbol": "regression",
+      "wikiPath": "wiki/synthesis/Best_Practices.md"
+    },
+    {
+      "path": "src/gamess_lsp/features/test_runner.py",
+      "symbol": "test_runner",
+      "wikiPath": "wiki/synthesis/openqc-agent-context.md"
+    },
+    {
+      "path": "src/gamess_lsp/features/typecheck.py",
+      "symbol": "typecheck",
+      "wikiPath": "wiki/synthesis/GAMESS_Input_Syntax.md"
+    },
+    {
+      "path": "src/gamess_lsp/keywords.py",
+      "symbol": "keywords",
+      "wikiPath": "wiki/synthesis/GAMESS_Input_Syntax.md"
+    },
+    {
+      "path": "src/gamess_lsp/output_parser.py",
+      "symbol": "output_parser",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "path": "src/gamess_lsp/parser.py",
+      "symbol": "parser",
+      "wikiPath": "wiki/synthesis/GAMESS_Input_Syntax.md"
+    },
+    {
+      "path": "src/gamess_lsp/preflight.py",
+      "symbol": "preflight",
+      "wikiPath": "wiki/synthesis/openqc-agent-context.md"
+    },
+    {
+      "path": "src/gamess_lsp/rich_diagnostics.py",
+      "symbol": "rich_diagnostics",
+      "wikiPath": "wiki/entities/Diagnostic_Engine.md"
+    },
+    {
+      "path": "src/gamess_lsp/server.py",
+      "symbol": "server",
+      "wikiPath": "wiki/entities/LSP_Server.md"
+    },
+    {
+      "path": "src/gamess_lsp/tokenizer.py",
+      "symbol": "tokenizer",
+      "wikiPath": "wiki/synthesis/GAMESS_Input_Syntax.md"
+    },
+    {
+      "path": "src/gamess_lsp/tool.py",
+      "symbol": "tool",
+      "wikiPath": "wiki/entities/OpenQC.md"
+    },
+    {
+      "path": "src/gamess_lsp/validator.py",
+      "symbol": "validator",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    }
+  ],
+  "generatedAt": "2026-06-15T20:21:20.322789+00:00",
+  "languageId": "gamess",
+  "rawManifest": {
+    "ok": true,
+    "path": "raw/assets/manifest.json"
+  },
+  "repository": "newtontech/gamess-lsp",
+  "ruleIds": [
+    {
+      "code": "GAMESS-INPUT-STRUCTURE-001",
+      "sourcePath": "src/gamess_lsp/features/lint.py"
+    },
+    {
+      "code": "GAMESS-INPUT-STRUCTURE-002",
+      "sourcePath": "src/gamess_lsp/features/lint.py"
+    },
+    {
+      "code": "GAMESS-INPUT-SCHEMA-001",
+      "sourcePath": "src/gamess_lsp/features/lint.py"
+    },
+    {
+      "code": "GAMESS-INPUT-SCHEMA-002",
+      "sourcePath": "src/gamess_lsp/features/lint.py"
+    },
+    {
+      "code": "GAMESS-INPUT-SCHEMA-003",
+      "sourcePath": "src/gamess_lsp/features/lint.py"
+    },
+    {
+      "code": "GAMESS-INPUT-SCHEMA-004",
+      "sourcePath": "src/gamess_lsp/features/lint.py"
+    },
+    {
+      "code": "GAMESS-INPUT-SCHEMA-005",
+      "sourcePath": "src/gamess_lsp/features/lint.py"
+    },
+    {
+      "code": "GAMESS-INPUT-BESTPRAC-001",
+      "sourcePath": "src/gamess_lsp/features/lint.py"
+    },
+    {
+      "code": "GAMESS-INPUT-BESTPRAC-002",
+      "sourcePath": "src/gamess_lsp/features/lint.py"
+    },
+    {
+      "code": "GAMESS-INPUT-BESTPRAC-003",
+      "sourcePath": "src/gamess_lsp/features/lint.py"
+    },
+    {
+      "code": "GAMESS-DIAG-SYNTAX-001",
+      "sourcePath": "src/gamess_lsp/features/diagnostic.py"
+    },
+    {
+      "code": "GAMESS-DIAG-SEMANTIC-001",
+      "sourcePath": "src/gamess_lsp/features/diagnostic.py"
+    },
+    {
+      "code": "GAMESS-DIAG-TYPECHECK-001",
+      "sourcePath": "src/gamess_lsp/features/typecheck.py"
+    },
+    {
+      "code": "GAMESS-OUTPUT-RUNTIME-001",
+      "sourcePath": "src/gamess_lsp/output_parser.py"
+    },
+    {
+      "code": "GAMESS-PREFLIGHT-ENVELOPE-001",
+      "sourcePath": "src/gamess_lsp/preflight.py"
+    }
+  ],
+  "schemaVersion": "openqc.lsp.traceability.v1",
+  "serverId": "gamess-lsp",
+  "sourceUrls": [
+    {
+      "rawPath": "raw/assets/DIAGNOSTIC_ENGINE_V1.md",
+      "url": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/DIAGNOSTIC_ENGINE_V1.md"
+    },
+    {
+      "rawPath": "raw/assets/OPENQC_ALIGNMENT.md",
+      "url": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/OPENQC_ALIGNMENT.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "url": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/README.md"
+    },
+    {
+      "rawPath": "raw/assets/agent-verification-loop.md",
+      "url": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/agent-verification-loop.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/README.md",
+      "url": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/README.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/h2o_freq.inp",
+      "url": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/h2o_freq.inp"
+    },
+    {
+      "rawPath": "raw/assets/examples/irc_reaction.inp",
+      "url": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/irc_reaction.inp"
+    },
+    {
+      "rawPath": "raw/assets/examples/mp2_energy.inp",
+      "url": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/mp2_energy.inp"
+    },
+    {
+      "rawPath": "raw/assets/examples/tddft_excited.inp",
+      "url": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/tddft_excited.inp"
+    },
+    {
+      "rawPath": "raw/assets/examples/water_dft.inp",
+      "url": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/water_dft.inp"
+    },
+    {
+      "rawPath": "raw/assets/manifest.json",
+      "url": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/manifest.json"
+    }
+  ],
+  "summary": {
+    "brokenWikiLinks": 0,
+    "docstringsLinked": 21,
+    "docstringsTotal": 21,
+    "rawManifestFailures": 0,
+    "ruleIdsTotal": 15,
+    "sourceUrlsTotal": 11,
+    "wikiSourcesTotal": 30,
+    "wikiSourcesWithoutRaw": 0
+  },
+  "wikiSources": [
+    {
+      "rawPath": "raw/assets/examples/water_dft.inp",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/water_dft.inp",
+      "wikiPath": "wiki/concepts/Basis_Sets.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/",
+      "wikiPath": "wiki/concepts/Calculation_Types.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/README.md",
+      "wikiPath": "wiki/concepts/DFT_Functionals.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/",
+      "wikiPath": "wiki/concepts/Electronic_Structure_Methods.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/tddft_excited.inp",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/tddft_excited.inp",
+      "wikiPath": "wiki/concepts/Excited_States.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/h2o_freq.inp",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/h2o_freq.inp",
+      "wikiPath": "wiki/concepts/Frequency_Calculation.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/water_dft.inp",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/water_dft.inp",
+      "wikiPath": "wiki/concepts/Geometry_Optimization.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/water_dft.inp",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/water_dft.inp",
+      "wikiPath": "wiki/concepts/Molecular_Orbitals.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/water_dft.inp",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/water_dft.inp",
+      "wikiPath": "wiki/concepts/Molecular_Symmetry.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/water_dft.inp",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/water_dft.inp",
+      "wikiPath": "wiki/concepts/SCF_Convergence.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/water_dft.inp",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/water_dft.inp",
+      "wikiPath": "wiki/concepts/Solvation_Models.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/h2o_freq.inp",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/h2o_freq.inp",
+      "wikiPath": "wiki/concepts/Thermodynamics.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/irc_reaction.inp",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/irc_reaction.inp",
+      "wikiPath": "wiki/concepts/Transition_State_Search.md"
+    },
+    {
+      "rawPath": "raw/assets/DIAGNOSTIC_ENGINE_V1.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/DIAGNOSTIC_ENGINE_V1.md",
+      "wikiPath": "wiki/concepts/diagnostic-engine-v1.md"
+    },
+    {
+      "rawPath": "raw/assets/DIAGNOSTIC_ENGINE_V1.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/DIAGNOSTIC_ENGINE_V1.md",
+      "wikiPath": "wiki/entities/Diagnostic_Engine.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/README.md",
+      "wikiPath": "wiki/entities/GAMESS.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/water_dft.inp",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/water_dft.inp",
+      "wikiPath": "wiki/entities/GAMESS.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/README.md",
+      "wikiPath": "wiki/entities/LSP_Server.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/README.md",
+      "wikiPath": "wiki/entities/OpenQC.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/README.md",
+      "wikiPath": "wiki/synthesis/Best_Practices.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/",
+      "wikiPath": "wiki/synthesis/Best_Practices.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/README.md",
+      "wikiPath": "wiki/synthesis/Code_Snippets.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/",
+      "wikiPath": "wiki/synthesis/Code_Snippets.md"
+    },
+    {
+      "rawPath": "raw/assets/DIAGNOSTIC_ENGINE_V1.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/DIAGNOSTIC_ENGINE_V1.md",
+      "wikiPath": "wiki/synthesis/Diagnostics_Catalog.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/README.md",
+      "wikiPath": "wiki/synthesis/GAMESS_Input_Syntax.md"
+    },
+    {
+      "rawPath": "raw/assets/examples/",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/examples/",
+      "wikiPath": "wiki/synthesis/GAMESS_Input_Syntax.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/README.md",
+      "wikiPath": "wiki/synthesis/LSP_Capabilities.md"
+    },
+    {
+      "rawPath": "raw/assets/README.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/README.md",
+      "wikiPath": "wiki/synthesis/Migration_Guide.md"
+    },
+    {
+      "rawPath": "raw/assets/agent-verification-loop.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/agent-verification-loop.md",
+      "wikiPath": "wiki/synthesis/Troubleshooting.md"
+    },
+    {
+      "rawPath": "raw/assets/OPENQC_ALIGNMENT.md",
+      "sourceUrl": "https://github.com/newtontech/gamess-lsp/blob/main/raw/assets/OPENQC_ALIGNMENT.md",
+      "wikiPath": "wiki/synthesis/openqc-agent-context.md"
+    }
+  ]
+}

--- a/scripts/check_docstring_traceability.py
+++ b/scripts/check_docstring_traceability.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python3
+"""Generate the OpenQC v1 docstring/wiki/raw traceability report for GAMESS."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import re
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+REPORT_PATH = REPO_ROOT / "reports" / "docstring-wiki-raw-traceability.json"
+SCHEMA_VERSION = "openqc.lsp.traceability.v1"
+SERVER_ID = "gamess-lsp"
+REPOSITORY = "newtontech/gamess-lsp"
+LANGUAGE_ID = "gamess"
+
+WIKI_RE = re.compile(r"wiki/(?:concepts|entities|synthesis)/[\w./-]+\.md")
+RAW_RE = re.compile(r"raw/assets/[\w./-]+")
+
+RULE_IDS: tuple[dict[str, str], ...] = (
+    {"code": "GAMESS-INPUT-STRUCTURE-001", "sourcePath": "src/gamess_lsp/features/lint.py"},
+    {"code": "GAMESS-INPUT-STRUCTURE-002", "sourcePath": "src/gamess_lsp/features/lint.py"},
+    {"code": "GAMESS-INPUT-SCHEMA-001", "sourcePath": "src/gamess_lsp/features/lint.py"},
+    {"code": "GAMESS-INPUT-SCHEMA-002", "sourcePath": "src/gamess_lsp/features/lint.py"},
+    {"code": "GAMESS-INPUT-SCHEMA-003", "sourcePath": "src/gamess_lsp/features/lint.py"},
+    {"code": "GAMESS-INPUT-SCHEMA-004", "sourcePath": "src/gamess_lsp/features/lint.py"},
+    {"code": "GAMESS-INPUT-SCHEMA-005", "sourcePath": "src/gamess_lsp/features/lint.py"},
+    {"code": "GAMESS-INPUT-BESTPRAC-001", "sourcePath": "src/gamess_lsp/features/lint.py"},
+    {"code": "GAMESS-INPUT-BESTPRAC-002", "sourcePath": "src/gamess_lsp/features/lint.py"},
+    {"code": "GAMESS-INPUT-BESTPRAC-003", "sourcePath": "src/gamess_lsp/features/lint.py"},
+    {"code": "GAMESS-DIAG-SYNTAX-001", "sourcePath": "src/gamess_lsp/features/diagnostic.py"},
+    {"code": "GAMESS-DIAG-SEMANTIC-001", "sourcePath": "src/gamess_lsp/features/diagnostic.py"},
+    {"code": "GAMESS-DIAG-TYPECHECK-001", "sourcePath": "src/gamess_lsp/features/typecheck.py"},
+    {"code": "GAMESS-OUTPUT-RUNTIME-001", "sourcePath": "src/gamess_lsp/output_parser.py"},
+    {"code": "GAMESS-PREFLIGHT-ENVELOPE-001", "sourcePath": "src/gamess_lsp/preflight.py"},
+)
+
+
+def repo_relative(path: Path) -> str:
+    """Return a repository-relative path."""
+    return str(path.relative_to(REPO_ROOT))
+
+
+def module_docstring(path: Path) -> str:
+    """Return a Python module docstring, or an empty string if parsing fails."""
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+    except SyntaxError:
+        return ""
+    return ast.get_docstring(tree) or ""
+
+
+def collect_docstrings() -> tuple[list[dict[str, str]], int, int, int]:
+    """Collect module docstring -> wiki links."""
+    entries: list[dict[str, str]] = []
+    total = 0
+    linked = 0
+    broken = 0
+    for path in sorted((REPO_ROOT / "src" / "gamess_lsp").rglob("*.py")):
+        doc = module_docstring(path)
+        if not doc:
+            continue
+        total += 1
+        wiki_paths = sorted(set(WIKI_RE.findall(doc)))
+        if wiki_paths:
+            linked += 1
+        for wiki_path in wiki_paths:
+            if not (REPO_ROOT / wiki_path).is_file():
+                broken += 1
+            entries.append(
+                {
+                    "path": repo_relative(path),
+                    "symbol": path.stem,
+                    "wikiPath": wiki_path,
+                }
+            )
+    return entries, total, linked, broken
+
+
+def collect_wiki_sources() -> tuple[list[dict[str, str]], int]:
+    """Collect wiki page -> raw evidence links."""
+    entries: list[dict[str, str]] = []
+    missing_raw = 0
+    for path in sorted((REPO_ROOT / "wiki").rglob("*.md")):
+        text = path.read_text(encoding="utf-8")
+        raw_paths = sorted(set(RAW_RE.findall(text)))
+        if not raw_paths:
+            missing_raw += 1
+            continue
+        for raw_path in raw_paths:
+            entries.append(
+                {
+                    "wikiPath": repo_relative(path),
+                    "rawPath": raw_path,
+                    "sourceUrl": f"https://github.com/{REPOSITORY}/blob/main/{raw_path}",
+                }
+            )
+    return entries, missing_raw
+
+
+def collect_source_urls() -> list[dict[str, str]]:
+    """Collect GitHub URLs for raw evidence assets."""
+    entries: list[dict[str, str]] = []
+    for path in sorted((REPO_ROOT / "raw" / "assets").rglob("*")):
+        if path.is_file():
+            raw_path = repo_relative(path)
+            entries.append(
+                {
+                    "rawPath": raw_path,
+                    "url": f"https://github.com/{REPOSITORY}/blob/main/{raw_path}",
+                }
+            )
+    return entries
+
+
+def raw_manifest_descriptor() -> dict[str, object]:
+    """Return the canonical raw manifest descriptor consumed by OpenQC."""
+    path = REPO_ROOT / "raw" / "assets" / "manifest.json"
+    return {
+        "path": repo_relative(path),
+        "ok": path.is_file() and path.stat().st_size > 0,
+    }
+
+
+def generate_report() -> dict[str, Any]:
+    """Generate the full traceability report."""
+    docstrings, total_docstrings, linked_docstrings, broken_wiki_links = collect_docstrings()
+    wiki_sources, wiki_sources_without_raw = collect_wiki_sources()
+    source_urls = collect_source_urls()
+    raw_manifest = raw_manifest_descriptor()
+    rule_ids = list(RULE_IDS)
+
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "serverId": SERVER_ID,
+        "repository": REPOSITORY,
+        "languageId": LANGUAGE_ID,
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "summary": {
+            "docstringsTotal": total_docstrings,
+            "docstringsLinked": linked_docstrings,
+            "brokenWikiLinks": broken_wiki_links,
+            "wikiSourcesWithoutRaw": wiki_sources_without_raw,
+            "rawManifestFailures": 0 if raw_manifest["ok"] else 1,
+            "ruleIdsTotal": len(rule_ids),
+            "sourceUrlsTotal": len(source_urls),
+            "wikiSourcesTotal": len(wiki_sources),
+        },
+        "docstrings": docstrings,
+        "wikiSources": wiki_sources,
+        "ruleIds": rule_ids,
+        "sourceUrls": source_urls,
+        "rawManifest": raw_manifest,
+    }
+
+
+def validate_report(report: dict[str, Any]) -> list[str]:
+    """Validate the report against the OpenQC checker contract."""
+    errors: list[str] = []
+    for field in [
+        "schemaVersion",
+        "serverId",
+        "repository",
+        "languageId",
+        "generatedAt",
+        "summary",
+        "docstrings",
+        "wikiSources",
+        "ruleIds",
+        "sourceUrls",
+        "rawManifest",
+    ]:
+        if field not in report:
+            errors.append(f"missing top-level field: {field}")
+    if errors:
+        return errors
+    if report["schemaVersion"] != SCHEMA_VERSION:
+        errors.append("wrong schemaVersion")
+    summary = report["summary"]
+    for field in [
+        "docstringsTotal",
+        "docstringsLinked",
+        "brokenWikiLinks",
+        "wikiSourcesWithoutRaw",
+        "rawManifestFailures",
+    ]:
+        if not isinstance(summary.get(field), int) or summary[field] < 0:
+            errors.append(f"summary.{field} must be a non-negative integer")
+    if summary.get("docstringsLinked") != summary.get("docstringsTotal"):
+        errors.append("not all module docstrings link to wiki pages")
+    if summary.get("brokenWikiLinks") != 0:
+        errors.append("broken wiki links found")
+    if summary.get("wikiSourcesWithoutRaw") != 0:
+        errors.append("wiki pages without raw evidence found")
+    if summary.get("rawManifestFailures") != 0:
+        errors.append("raw manifest failure found")
+    rule_pattern = re.compile(r"^[A-Z]+-[A-Z]+-[A-Z]+-\d{3}$")
+    for item in report["ruleIds"]:
+        if not rule_pattern.fullmatch(item.get("code", "")):
+            errors.append(f"bad rule id: {item.get('code')}")
+    raw_manifest = report["rawManifest"]
+    if not isinstance(raw_manifest, dict):
+        errors.append("rawManifest must be an object")
+    elif not isinstance(raw_manifest.get("path"), str) or not isinstance(
+        raw_manifest.get("ok"), bool
+    ):
+        errors.append("rawManifest must contain path and ok")
+    return errors
+
+
+def main() -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--write-report", action="store_true")
+    parser.add_argument("--strict", action="store_true")
+    args = parser.parse_args()
+    report = generate_report()
+    errors = validate_report(report)
+    if args.write_report:
+        REPORT_PATH.parent.mkdir(parents=True, exist_ok=True)
+        REPORT_PATH.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        print(f"Report written to {REPORT_PATH}")
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        return 1 if args.strict else 0
+    print(json.dumps(report["summary"], indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/gamess_lsp/__init__.py
+++ b/src/gamess_lsp/__init__.py
@@ -1,4 +1,7 @@
-"""GAMESS Language Server Protocol implementation."""
+"""GAMESS Language Server Protocol implementation.
+
+See also: wiki/entities/GAMESS.md
+"""
 
 __version__ = "0.1.0"
 

--- a/src/gamess_lsp/agent_lsp.py
+++ b/src/gamess_lsp/agent_lsp.py
@@ -1,4 +1,7 @@
-"""Small Python API wrapper around the Diagnostic Engine v1 CLI contract."""
+"""Small Python API wrapper around the Diagnostic Engine v1 CLI contract.
+
+See also: wiki/entities/LSP_Server.md
+"""
 
 from __future__ import annotations
 

--- a/src/gamess_lsp/agent_operations.py
+++ b/src/gamess_lsp/agent_operations.py
@@ -1,5 +1,7 @@
 """Shared agent-facing operations for Diagnostic Engine v1 CLIs.
 
+See also: wiki/entities/LSP_Server.md
+
 The editor servers already own the expensive parsing and validation logic. This
 module exposes the same information in a command-line friendly JSON shape for
 agents that need LSP-style context without starting an editor client.

--- a/src/gamess_lsp/constants.py
+++ b/src/gamess_lsp/constants.py
@@ -1,4 +1,7 @@
-"""Shared constants for GAMESS LSP."""
+"""Shared constants for GAMESS LSP.
+
+See also: wiki/synthesis/GAMESS_Input_Syntax.md
+"""
 
 # Atomic numbers for elements H through U
 ELEMENT_ATOMIC_NUMBERS = {

--- a/src/gamess_lsp/features/__init__.py
+++ b/src/gamess_lsp/features/__init__.py
@@ -1,1 +1,4 @@
-"""LSP feature providers for GAMESS Language Server."""
+"""LSP feature providers for GAMESS Language Server.
+
+See also: wiki/entities/LSP_Server.md
+"""

--- a/src/gamess_lsp/features/agent_api.py
+++ b/src/gamess_lsp/features/agent_api.py
@@ -1,5 +1,7 @@
 """Machine-readable code-intelligence API for AI coding agents.
 
+See also: wiki/entities/OpenQC.md
+
 Exposes domain language descriptions (#58), section/keyword schema lookup (#59),
 minimal examples and next-token guidance (#60), and the OpenQC smoke capability (#76).
 """

--- a/src/gamess_lsp/features/diagnostic.py
+++ b/src/gamess_lsp/features/diagnostic.py
@@ -1,5 +1,7 @@
 """LSP diagnostic provider for GAMESS input files.
 
+See also: wiki/entities/Diagnostic_Engine.md
+
 Exposes live diagnostics snapshots suitable for both LSP clients and
 machine-readable agent feedback loops.
 """

--- a/src/gamess_lsp/features/formatting.py
+++ b/src/gamess_lsp/features/formatting.py
@@ -1,5 +1,7 @@
 """LSP formatting provider for GAMESS input files.
 
+See also: wiki/synthesis/GAMESS_Input_Syntax.md
+
 This module provides document and range formatting for GAMESS input files,
 including group indentation, keyword normalization (uppercase), comment
 preservation, and $DATA section handling.

--- a/src/gamess_lsp/features/lint.py
+++ b/src/gamess_lsp/features/lint.py
@@ -1,5 +1,7 @@
 """Schema-aware static lint rules for GAMESS input files.
 
+See also: wiki/synthesis/Diagnostics_Catalog.md
+
 Exposes ``LintProvider`` which produces LSP ``Diagnostic`` objects from
 deterministic, offline checks against the curated keyword metadata in
 :mod:`gamess_lsp.keywords`.  Every diagnostic carries a stable rule code

--- a/src/gamess_lsp/features/regression.py
+++ b/src/gamess_lsp/features/regression.py
@@ -1,4 +1,7 @@
-"""Regression harness for golden diagnostics, formatting, and code actions."""
+"""Regression harness for golden diagnostics, formatting, and code actions.
+
+See also: wiki/synthesis/Best_Practices.md
+"""
 
 from __future__ import annotations
 

--- a/src/gamess_lsp/features/test_runner.py
+++ b/src/gamess_lsp/features/test_runner.py
@@ -1,4 +1,7 @@
-"""Optional test-runner / dry-run bridge for GAMESS."""
+"""Optional test-runner / dry-run bridge for GAMESS.
+
+See also: wiki/synthesis/openqc-agent-context.md
+"""
 
 from __future__ import annotations
 

--- a/src/gamess_lsp/features/typecheck.py
+++ b/src/gamess_lsp/features/typecheck.py
@@ -1,5 +1,7 @@
 """Type-checking validation for GAMESS keyword values.
 
+See also: wiki/synthesis/GAMESS_Input_Syntax.md
+
 Validates keyword value types (integer, float, boolean, enum, string),
 checks enum membership against the keyword database, validates units where
 applicable, and reports missing required sections.

--- a/src/gamess_lsp/keywords.py
+++ b/src/gamess_lsp/keywords.py
@@ -1,4 +1,7 @@
-"""GAMESS keywords database."""
+"""GAMESS keywords database.
+
+See also: wiki/synthesis/GAMESS_Input_Syntax.md
+"""
 
 GAMESS_GROUPS = {
     "CONTRL": """$CONTRL group - Main control options for GAMESS calculation.

--- a/src/gamess_lsp/output_parser.py
+++ b/src/gamess_lsp/output_parser.py
@@ -1,5 +1,7 @@
 """GAMESS output/log file parser for runtime diagnostics.
 
+See also: wiki/synthesis/Diagnostics_Catalog.md
+
 This module parses GAMESS output files (.log, .out) to extract runtime
 diagnostics, warnings, and error information that can be used by the LSP
 to provide feedback on calculation issues.

--- a/src/gamess_lsp/parser.py
+++ b/src/gamess_lsp/parser.py
@@ -1,4 +1,7 @@
-"""GAMESS input file parser."""
+"""GAMESS input file parser.
+
+See also: wiki/synthesis/GAMESS_Input_Syntax.md
+"""
 
 import re
 from dataclasses import dataclass, field

--- a/src/gamess_lsp/preflight.py
+++ b/src/gamess_lsp/preflight.py
@@ -1,5 +1,7 @@
 """Universal generated-input preflight capabilities.
 
+See also: wiki/synthesis/openqc-agent-context.md
+
 This module implements the four fleet-wide preflight capabilities called out in
 ``newtontech/gamess-lsp#82`` against a *generic artifact-role model*, so the
 checks generalize to any backend in the scientific LSP fleet instead of being

--- a/src/gamess_lsp/rich_diagnostics.py
+++ b/src/gamess_lsp/rich_diagnostics.py
@@ -1,5 +1,7 @@
 """Diagnostic Engine v1 serialization helpers.
 
+See also: wiki/entities/Diagnostic_Engine.md
+
 The module keeps existing LSP/provider diagnostics untouched and provides a
 python-lsp-server-style provider boundary for agent-facing JSON consumers.
 """

--- a/src/gamess_lsp/server.py
+++ b/src/gamess_lsp/server.py
@@ -1,4 +1,7 @@
-"""GAMESS Language Server Protocol implementation."""
+"""GAMESS Language Server Protocol implementation.
+
+See also: wiki/entities/LSP_Server.md
+"""
 
 import logging
 import os

--- a/src/gamess_lsp/tokenizer.py
+++ b/src/gamess_lsp/tokenizer.py
@@ -1,5 +1,7 @@
 """Shared tokenizer for GAMESS keyword/value parsing.
 
+See also: wiki/synthesis/GAMESS_Input_Syntax.md
+
 Provides both low-level line tokenization and higher-level keyword=value
 pair extraction, eliminating duplication between parser and formatter
 (issue #66).

--- a/src/gamess_lsp/tool.py
+++ b/src/gamess_lsp/tool.py
@@ -1,4 +1,7 @@
-"""Agent-facing CLI for Diagnostic Engine v1 operations."""
+"""Agent-facing CLI for Diagnostic Engine v1 operations.
+
+See also: wiki/entities/OpenQC.md
+"""
 
 from __future__ import annotations
 

--- a/src/gamess_lsp/validator.py
+++ b/src/gamess_lsp/validator.py
@@ -1,5 +1,7 @@
 """Semantic validation rules for GAMESS input files.
 
+See also: wiki/synthesis/Diagnostics_Catalog.md
+
 This module provides physics/chemistry-aware validation that goes beyond
 syntax checking to detect semantically incorrect but syntactically valid inputs.
 

--- a/tests/test_docstring_traceability.py
+++ b/tests/test_docstring_traceability.py
@@ -1,0 +1,82 @@
+"""Tests for the OpenQC v1 docstring/wiki/raw traceability report."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, cast
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPORT_PATH = REPO_ROOT / "reports" / "docstring-wiki-raw-traceability.json"
+CHECKER = REPO_ROOT / "scripts" / "check_docstring_traceability.py"
+
+
+def load_report() -> dict[str, Any]:
+    """Load the committed traceability report."""
+    return cast(dict[str, Any], json.loads(REPORT_PATH.read_text(encoding="utf-8")))
+
+
+def test_traceability_report_schema_contract() -> None:
+    report = load_report()
+    assert report["schemaVersion"] == "openqc.lsp.traceability.v1"
+    assert report["serverId"] == "gamess-lsp"
+    assert report["repository"] == "newtontech/gamess-lsp"
+    assert report["languageId"] == "gamess"
+    for field in ["summary", "docstrings", "wikiSources", "ruleIds", "sourceUrls", "rawManifest"]:
+        assert field in report
+
+
+def test_summary_has_zero_failures() -> None:
+    summary = load_report()["summary"]
+    assert summary["docstringsTotal"] == summary["docstringsLinked"]
+    assert summary["brokenWikiLinks"] == 0
+    assert summary["wikiSourcesWithoutRaw"] == 0
+    assert summary["rawManifestFailures"] == 0
+
+
+def test_docstring_links_exist() -> None:
+    for entry in load_report()["docstrings"]:
+        assert (REPO_ROOT / entry["path"]).is_file()
+        assert (REPO_ROOT / entry["wikiPath"]).is_file()
+        assert entry["wikiPath"].startswith("wiki/")
+
+
+def test_wiki_sources_link_to_raw_assets() -> None:
+    for entry in load_report()["wikiSources"]:
+        assert (REPO_ROOT / entry["wikiPath"]).is_file()
+        assert (REPO_ROOT / entry["rawPath"]).exists()
+        assert entry["sourceUrl"].startswith("https://github.com/newtontech/gamess-lsp/")
+
+
+def test_rule_ids_match_openqc_pattern() -> None:
+    pattern = re.compile(r"^[A-Z]+-[A-Z]+-[A-Z]+-\d{3}$")
+    for entry in load_report()["ruleIds"]:
+        assert pattern.fullmatch(entry["code"])
+        assert (REPO_ROOT / entry["sourcePath"]).is_file()
+
+
+def test_source_urls_are_repo_relative_raw_links() -> None:
+    for entry in load_report()["sourceUrls"]:
+        assert entry["rawPath"].startswith("raw/assets/")
+        assert (REPO_ROOT / entry["rawPath"]).is_file()
+        assert entry["url"].startswith("https://github.com/newtontech/gamess-lsp/")
+
+
+def test_raw_manifest_descriptor() -> None:
+    raw_manifest = load_report()["rawManifest"]
+    assert raw_manifest == {"path": "raw/assets/manifest.json", "ok": True}
+    assert (REPO_ROOT / raw_manifest["path"]).is_file()
+
+
+def test_checker_regenerates_report() -> None:
+    result = subprocess.run(
+        [sys.executable, str(CHECKER), "--write-report", "--strict"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/wiki/concepts/DFT_Functionals.md
+++ b/wiki/concepts/DFT_Functionals.md
@@ -208,3 +208,6 @@ $DFT METHOD=GRID $END
 ## 来源 / Sources
 
 - `src/gamess_lsp/keywords.py` - DFT 组关键词
+## Raw evidence
+
+- raw/assets/README.md

--- a/wiki/concepts/Molecular_Orbitals.md
+++ b/wiki/concepts/Molecular_Orbitals.md
@@ -215,3 +215,6 @@ $VEC
 ## 来源 / Sources
 
 - `src/gamess_lsp/keywords.py` - GUESS, VEC 组关键词
+## Raw evidence
+
+- raw/assets/examples/water_dft.inp

--- a/wiki/concepts/SCF_Convergence.md
+++ b/wiki/concepts/SCF_Convergence.md
@@ -247,3 +247,6 @@ $CONTRL MAXIT=200 $END
 
 - `src/gamess_lsp/keywords.py` - SCF, CONTRL 组关键词
 - `docs/DIAGNOSTIC_ENGINE_V1.md` - 诊断信息
+## Raw evidence
+
+- raw/assets/examples/water_dft.inp

--- a/wiki/concepts/Solvation_Models.md
+++ b/wiki/concepts/Solvation_Models.md
@@ -116,3 +116,6 @@ $PCM SOLVNT=WATER $END
 ## 来源 / Sources
 
 - `src/gamess_lsp/keywords.py` - PCM, COSMO, SMD 关键词
+## Raw evidence
+
+- raw/assets/examples/water_dft.inp

--- a/wiki/concepts/diagnostic-engine-v1.md
+++ b/wiki/concepts/diagnostic-engine-v1.md
@@ -1,3 +1,6 @@
 # Diagnostic Engine v1
 
 GAMESS diagnostics use `DiagnosticEnvelope/v1` with `error`, `warning`, `information`, and `hint` severities. Blocking behavior is controlled by `lsp-capabilities.json`, not by OpenQC guesswork.
+## Raw evidence
+
+- raw/assets/DIAGNOSTIC_ENGINE_V1.md

--- a/wiki/entities/Diagnostic_Engine.md
+++ b/wiki/entities/Diagnostic_Engine.md
@@ -82,3 +82,6 @@ gamess-lsp-tool fix path/to/input --format json
 ## 历史更新 / History
 
 - 2026-06-12: 创建诊断引擎实体页面
+## Raw evidence
+
+- raw/assets/DIAGNOSTIC_ENGINE_V1.md

--- a/wiki/synthesis/Diagnostics_Catalog.md
+++ b/wiki/synthesis/Diagnostics_Catalog.md
@@ -241,3 +241,6 @@ $CONTRL SCFTYP=RHF $END
 - `docs/DIAGNOSTIC_ENGINE_V1.md` - 诊断引擎规范
 - `src/gamess_lsp/validator.py` - 诊断实现
 - `src/gamess_lsp/rich_diagnostics.py` - 丰富诊断格式
+## Raw evidence
+
+- raw/assets/DIAGNOSTIC_ENGINE_V1.md

--- a/wiki/synthesis/Troubleshooting.md
+++ b/wiki/synthesis/Troubleshooting.md
@@ -312,3 +312,6 @@ $CONTRL ... $END
 
 - `src/gamess_lsp/keywords.py` - 关键词参考
 - `docs/DIAGNOSTIC_ENGINE_V1.md` - 诊断信息
+## Raw evidence
+
+- raw/assets/agent-verification-loop.md

--- a/wiki/synthesis/openqc-agent-context.md
+++ b/wiki/synthesis/openqc-agent-context.md
@@ -1,3 +1,6 @@
 # OpenQC Agent Context
 
 OpenQC consumes `gamess-lsp-tool` and `lsp-capabilities.json` to assemble diagnostics, hover, completion, symbols, examples, next-token guidance, and repair-plan hints for `gamess` documents.
+## Raw evidence
+
+- raw/assets/OPENQC_ALIGNMENT.md


### PR DESCRIPTION
## Summary

Implements the OpenQC v1 docstring/wiki/raw traceability report for GAMESS LSP.

## Changes

- Adds `scripts/check_docstring_traceability.py` to generate `reports/docstring-wiki-raw-traceability.json` with `schemaVersion: openqc.lsp.traceability.v1`.
- Links every `src/gamess_lsp/**/*.py` module docstring to a concrete `wiki/` page with `See also:`.
- Adds raw evidence references to wiki pages that previously had no `raw/assets/...` link.
- Uses the existing `raw/assets/manifest.json` as the canonical `rawManifest.path` descriptor.
- Adds focused tests for the report schema, source docstring links, wiki/raw links, OpenQC rule ID shape, source URLs, raw manifest descriptor, and regeneration.

## Test Plan

```bash
python3 scripts/check_docstring_traceability.py --write-report --strict
python3 -m pytest tests/test_docstring_traceability.py -q --no-cov
python3 -m black --check scripts/check_docstring_traceability.py tests/test_docstring_traceability.py
python3 -m flake8 scripts/check_docstring_traceability.py tests/test_docstring_traceability.py
python3 -m compileall -q src scripts
python3 -m mypy --python-version 3.10 --follow-imports=skip --ignore-missing-imports tests/test_docstring_traceability.py
git diff --check
```

Closes #97
